### PR TITLE
Add Persian verbose names for models

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -18,5 +18,9 @@ class User(AbstractUser):
         help_text="The institution this user belongs to."
     )
 
+    class Meta:
+        verbose_name = "کاربر"
+        verbose_name_plural = "کاربران"
+
     def __str__(self):
         return f"{self.username} ({self.institution.name if self.institution else 'No Institution'})"

--- a/courses/models/course_model.py
+++ b/courses/models/course_model.py
@@ -18,8 +18,8 @@ class Course(BaseModel):
     is_active = models.BooleanField(default=True)
 
     class Meta:
-        verbose_name = "Course"
-        verbose_name_plural = "Courses"
+        verbose_name = "درس"
+        verbose_name_plural = "دروس"
 
     def __str__(self):
         return f"{self.title} ({self.offer_code})"

--- a/institutions/models/institution.py
+++ b/institutions/models/institution.py
@@ -13,8 +13,8 @@ class Institution(BaseModel):
     is_active = models.BooleanField(default=True)
 
     class Meta:
-        verbose_name = "Institution"
-        verbose_name_plural = "Institutions"
+        verbose_name = "مؤسسه"
+        verbose_name_plural = "مؤسسات"
 
     def __str__(self):
         return self.name

--- a/locations/models/building_model.py
+++ b/locations/models/building_model.py
@@ -18,8 +18,8 @@ class Building(BaseModel):
     )
 
     class Meta:
-        verbose_name = "Building"
-        verbose_name_plural = "Buildings"
+        verbose_name = "ساختمان"
+        verbose_name_plural = "ساختمان‌ها"
 
     def __str__(self):
         return self.title

--- a/locations/models/classroom_model.py
+++ b/locations/models/classroom_model.py
@@ -11,8 +11,8 @@ class Classroom(BaseModel):
     building = models.ForeignKey(Building, on_delete=models.CASCADE, related_name="classrooms")
 
     class Meta:
-        verbose_name = "Classroom"
-        verbose_name_plural = "Classrooms"
+        verbose_name = "کلاس"
+        verbose_name_plural = "کلاس‌ها"
 
     def __str__(self):
         return f"{self.title} ({self.building.title})"

--- a/professors/models/professor.py
+++ b/professors/models/professor.py
@@ -15,8 +15,8 @@ class Professor(BaseModel):
     phone_number = models.CharField(max_length=15, blank=True, null=True)
 
     class Meta:
-        verbose_name = "Professor"
-        verbose_name_plural = "Professors"
+        verbose_name = "استاد"
+        verbose_name_plural = "اساتید"
 
     def __str__(self):
         return f"{self.first_name} {self.last_name}"

--- a/schedules/models/class_session_model.py
+++ b/schedules/models/class_session_model.py
@@ -41,8 +41,8 @@ class ClassSession(BaseModel):
     note = models.TextField(blank=True, null=True)
 
     class Meta:
-        verbose_name = "Class Session"
-        verbose_name_plural = "Class Sessions"
+        verbose_name = "جلسه کلاس"
+        verbose_name_plural = "جلسات کلاس"
 
     def __str__(self) -> str:  # pragma: no cover - simple representation
         return f"{self.course.title} - {self.day_of_week}" 

--- a/semesters/models/semester.py
+++ b/semesters/models/semester.py
@@ -29,8 +29,8 @@ class Semester(BaseModel):
     )
 
     class Meta:
-        verbose_name = "Semester"
-        verbose_name_plural = "Semesters"
+        verbose_name = "ترم"
+        verbose_name_plural = "ترم‌ها"
 
     def __str__(self):
         return f"{self.title} - {self.institution.name}"


### PR DESCRIPTION
## Summary
- Localized model `verbose_name` and `verbose_name_plural` fields to Persian across core apps.

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_68a4721bd544832ab2ed2a85f4cfa2c5