### PR TITLE
chore: normalize error codes

### DIFF
--- a/unischedule/core/error_codes.py
+++ b/unischedule/core/error_codes.py
@@ -2,180 +2,180 @@ from rest_framework import status
 
 
 class ErrorCodes:
+    # Generic
+    VALIDATION_FAILED = {
+        "code": "4000",
+        "message": "اطلاعات وارد شده نامعتبر است.",
+        "status_code": status.HTTP_400_BAD_REQUEST,
+        "errors": [],
+        "data": {},
+    }
+
+    # Semester
     SEMESTER_NOT_FOUND = {
         "code": "4100",
         "message": "ترم مورد نظر یافت نشد.",
         "status_code": status.HTTP_404_NOT_FOUND,
         "errors": [],
-        "data": {}
+        "data": {},
     }
-
     SEMESTER_CREATION_FAILED = {
         "code": "4101",
         "message": "ایجاد ترم با خطا مواجه شد.",
         "status_code": status.HTTP_400_BAD_REQUEST,
         "errors": [],
-        "data": {}
+        "data": {},
     }
-    VALIDATION_FAILED = {
-        "code": "4102",
-        "message": "اطلاعات وارد شده نامعتبر است.",
-        "status_code": status.HTTP_400_BAD_REQUEST,
-        "errors": [],
-        "data": {}
-    }
-
     SEMESTER_UPDATE_FAILED = {
         "code": "4102",
         "message": "ویرایش ترم با خطا مواجه شد.",
         "status_code": status.HTTP_400_BAD_REQUEST,
         "errors": [],
-        "data": {}
+        "data": {},
     }
-
     SEMESTER_DELETE_FAILED = {
         "code": "4103",
         "message": "حذف ترم با خطا مواجه شد.",
         "status_code": status.HTTP_400_BAD_REQUEST,
         "errors": [],
-        "data": {}
+        "data": {},
     }
-
     SEMESTER_ALREADY_ACTIVE = {
         "code": "4104",
         "message": "ترم انتخاب‌شده هم‌اکنون فعال است.",
         "status_code": status.HTTP_400_BAD_REQUEST,
         "errors": [],
-        "data": {}
+        "data": {},
     }
+
+    # Professor
     PROFESSOR_NOT_FOUND = {
         "code": "4200",
         "message": "استاد مورد نظر یافت نشد.",
         "status_code": status.HTTP_404_NOT_FOUND,
         "errors": [],
-        "data": {}
+        "data": {},
     }
-
     PROFESSOR_CREATION_FAILED = {
         "code": "4201",
         "message": "ایجاد استاد با خطا مواجه شد.",
         "status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
         "errors": [],
-        "data": {}
+        "data": {},
     }
-
     PROFESSOR_UPDATE_FAILED = {
         "code": "4202",
         "message": "به‌روزرسانی اطلاعات استاد با خطا مواجه شد.",
         "status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
         "errors": [],
-        "data": {}
+        "data": {},
     }
-
     PROFESSOR_DELETION_FAILED = {
         "code": "4203",
         "message": "حذف استاد با خطا مواجه شد.",
         "status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
         "errors": [],
-        "data": {}
+        "data": {},
     }
-    # === COURSE ===
+
+    # Course
     COURSE_CREATION_FAILED = {
         "code": "4301",
         "message": "ایجاد درس با خطا مواجه شد.",
-        "status_code": 500,
+        "status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
         "errors": [],
-        "data": {}
+        "data": {},
     }
-
     COURSE_UPDATE_FAILED = {
         "code": "4302",
         "message": "به‌روزرسانی اطلاعات درس با خطا مواجه شد.",
-        "status_code": 500,
+        "status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
         "errors": [],
-        "data": {}
+        "data": {},
     }
-
     COURSE_DELETION_FAILED = {
         "code": "4303",
         "message": "حذف درس با خطا مواجه شد.",
-        "status_code": 500,
+        "status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
         "errors": [],
-        "data": {}
+        "data": {},
     }
-
     COURSE_NOT_FOUND = {
         "code": "4304",
         "message": "درس مورد نظر یافت نشد.",
-        "status_code": 404,
+        "status_code": status.HTTP_404_NOT_FOUND,
         "errors": [],
-        "data": {}
+        "data": {},
     }
-
     COURSE_VALIDATION_FAILED = {
         "code": "4305",
         "message": "اطلاعات وارد شده نامعتبر است.",
-        "status_code": 400,
+        "status_code": status.HTTP_400_BAD_REQUEST,
         "errors": [],
-        "data": {}
+        "data": {},
     }
 
-    # Buildings
+    # Building
     BUILDING_NOT_FOUND = {
-        "code": "4100",
+        "code": "4400",
         "message": "ساختمان مورد نظر یافت نشد.",
-        "status_code": 404,
-        "errors": []
+        "status_code": status.HTTP_404_NOT_FOUND,
+        "errors": [],
+        "data": {},
     }
     BUILDING_CREATION_FAILED = {
         "code": "4401",
         "message": "ایجاد ساختمان با خطا مواجه شد.",
-        "status_code": 500,
-        "errors": []
+        "status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "errors": [],
+        "data": {},
     }
     BUILDING_UPDATE_FAILED = {
         "code": "4402",
         "message": "به‌روزرسانی اطلاعات ساختمان با خطا مواجه شد.",
-        "status_code": 500,
-        "errors": []
+        "status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "errors": [],
+        "data": {},
     }
     BUILDING_DELETION_FAILED = {
         "code": "4403",
         "message": "حذف ساختمان با خطا مواجه شد.",
-        "status_code": 500,
-        "errors": []
+        "status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "errors": [],
+        "data": {},
     }
 
-    # --------- Classroom Error Codes ---------
+    # Classroom
     CLASSROOM_NOT_FOUND = {
-        "code": "4100",
+        "code": "4500",
         "message": "کلاس مورد نظر یافت نشد.",
-        "status_code": 404,
-        "errors": []
+        "status_code": status.HTTP_404_NOT_FOUND,
+        "errors": [],
+        "data": {},
     }
-
     CLASSROOM_CREATION_FAILED = {
         "code": "4501",
         "message": "ایجاد کلاس با خطا مواجه شد.",
-        "status_code": 500,
-        "errors": []
+        "status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "errors": [],
+        "data": {},
     }
-
     CLASSROOM_UPDATE_FAILED = {
         "code": "4502",
         "message": "به‌روزرسانی اطلاعات کلاس با خطا مواجه شد.",
-        "status_code": 500,
-        "errors": []
+        "status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "errors": [],
+        "data": {},
     }
-
     CLASSROOM_DELETION_FAILED = {
         "code": "4503",
         "message": "حذف کلاس با خطا مواجه شد.",
-        "status_code": 500,
-        "errors": []
+        "status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "errors": [],
+        "data": {},
     }
 
-    # Class Session Errors
+    # Class Session
     CLASS_SESSION_NOT_FOUND = {
         "code": "4600",
         "message": "جلسه کلاس مورد نظر یافت نشد.",
@@ -211,31 +211,33 @@ class ErrorCodes:
         "errors": [],
         "data": {},
     }
-    # ✅ Auth
+
+    # Auth
     INVALID_CREDENTIALS = {
-        "code": 4101,
+        "code": "4700",
         "message": "نام کاربری یا رمز عبور اشتباه است.",
-        "status_code": 401,
-        "errors": ["Invalid username or password."]
+        "status_code": status.HTTP_401_UNAUTHORIZED,
+        "errors": ["Invalid username or password."],
+        "data": {},
     }
-
     LOGIN_FAILED = {
-        "code": 4501,
+        "code": "4701",
         "message": "ورود با خطا مواجه شد.",
-        "status_code": 500,
-        "errors": ["Login failed due to a server error."]
+        "status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "errors": ["Login failed due to a server error."],
+        "data": {},
     }
-
     TOKEN_NOT_FOUND = {
-        "code": 4201,
+        "code": "4702",
         "message": "توکن کاربر یافت نشد.",
-        "status_code": 404,
+        "status_code": status.HTTP_404_NOT_FOUND,
         "errors": [],
+        "data": {},
     }
-
     LOGOUT_FAILED = {
-        "code": 4501,
+        "code": "4703",
         "message": "خروج از حساب با خطا مواجه شد.",
-        "status_code": 500,
+        "status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
         "errors": [],
+        "data": {},
     }


### PR DESCRIPTION
## Summary
- assign unique prefixes to each error code domain
- add shared keys and DRF status constants to error code definitions

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a4c3388ba0832a9d8ad00ecd1ade9b