### PR TITLE
Use logging for error handling and configure Django logging

### DIFF
--- a/locations/views/building_view.py
+++ b/locations/views/building_view.py
@@ -9,7 +9,10 @@ from unischedule.core.success_codes import SuccessCodes
 from unischedule.core.error_codes import ErrorCodes
 
 from locations.services import building_service
-import traceback
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 @api_view(["GET"])
@@ -62,8 +65,7 @@ def create_building_view(request):
             status_code=status.HTTP_201_CREATED
         )
     except CustomValidationError as e:
-        print("Unhandled Exception:", str(e))
-        traceback.print_exc()
+        logger.exception("Validation error while creating building")
         return BaseResponse.error(
             message=e.detail["message"],
             code=e.detail["code"],
@@ -71,9 +73,8 @@ def create_building_view(request):
             errors=e.detail["errors"],
             data=e.detail["data"]
         )
-    except Exception as e:
-        print("Unhandled Exception:", str(e))
-        traceback.print_exc()
+    except Exception:
+        logger.exception("Unhandled exception while creating building")
         return BaseResponse.error(
             message=ErrorCodes.BUILDING_CREATION_FAILED["message"],
             code=ErrorCodes.BUILDING_CREATION_FAILED["code"],

--- a/professors/views/professor_view.py
+++ b/professors/views/professor_view.py
@@ -9,7 +9,10 @@ from unischedule.core.success_codes import SuccessCodes
 from unischedule.core.error_codes import ErrorCodes
 
 from professors.services import professor_service
-import traceback
+import logging
+
+
+logger = logging.getLogger(__name__)
 
 
 @api_view(["GET"])
@@ -110,10 +113,8 @@ def update_professor_view(request, professor_id):
             errors=e.detail
         )
 
-    except Exception as e:
-        import traceback
-        print("Unhandled Exception:", str(e))
-        traceback.print_exc()
+    except Exception:
+        logger.exception("Unhandled exception while updating professor")
         return BaseResponse.error(
             message=ErrorCodes.PROFESSOR_UPDATE_FAILED["message"],
             code=ErrorCodes.PROFESSOR_UPDATE_FAILED["code"],
@@ -137,9 +138,8 @@ def delete_professor_view(request, professor_id):
             message=SuccessCodes.PROFESSOR_DELETED["message"],
             code=SuccessCodes.PROFESSOR_DELETED["code"]
         )
-    except Exception as e:
-        print("Unhandled Exception:", str(e))
-        traceback.print_exc()
+    except Exception:
+        logger.exception("Unhandled exception while deleting professor")
         return BaseResponse.error(
             message=ErrorCodes.PROFESSOR_DELETION_FAILED["message"],
             code=ErrorCodes.PROFESSOR_DELETION_FAILED["code"],

--- a/unischedule/settings.py
+++ b/unischedule/settings.py
@@ -141,3 +141,18 @@ REST_FRAMEWORK = {
 }
 
 AUTH_USER_MODEL = 'accounts.User'
+
+# Logging configuration
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'ERROR',
+    },
+}


### PR DESCRIPTION
## Summary
- replace `print` and `traceback.print_exc` calls with structured logging
- add a basic error logging configuration in Django settings

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a4c34cf998832a8aac4ecea6324fd2