### PR TITLE
Handle duplicate professor national code

### DIFF
--- a/professors/serializers/professor_serializer.py
+++ b/professors/serializers/professor_serializer.py
@@ -35,6 +35,15 @@ class CreateProfessorSerializer(serializers.ModelSerializer):
     def validate_national_code(self, value):
         if not value.isdigit() or len(value) != 10:
             raise serializers.ValidationError("کد ملی باید ۱۰ رقم و فقط عدد باشد.")
+
+        institution = self.context.get("institution")
+        if (
+            institution
+            and Professor.objects.filter(national_code=value, institution=institution).exists()
+        ):
+            raise serializers.ValidationError(
+                "استادی با این کد ملی در این مؤسسه وجود دارد."
+            )
         return value
 
 

--- a/professors/tests/test_professor_creation.py
+++ b/professors/tests/test_professor_creation.py
@@ -1,0 +1,30 @@
+from django.urls import reverse
+from rest_framework.test import APIClient
+from rest_framework import status
+from django.test import TestCase
+from institutions.models import Institution
+from accounts.models import User
+
+
+class ProfessorCreationTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.institution = Institution.objects.create(name="Test Institution", slug="test-institution")
+        self.user = User.objects.create_user(
+            username="testuser", password="password", institution=self.institution
+        )
+        self.client.force_authenticate(user=self.user)
+        self.url = reverse("create-professor")
+        self.professor_data = {
+            "first_name": "Ali",
+            "last_name": "Reza",
+            "national_code": "1234567890",
+            "phone_number": "09123456789",
+        }
+
+    def test_duplicate_national_code_returns_400(self):
+        first_response = self.client.post(self.url, self.professor_data, format="json")
+        self.assertEqual(first_response.status_code, status.HTTP_201_CREATED)
+
+        second_response = self.client.post(self.url, self.professor_data, format="json")
+        self.assertEqual(second_response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Summary
- validate national code uniqueness within an institution
- convert create professor DB/validation errors to CustomValidationError
- test duplicate national code returns 400

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python manage.py test professors.tests.test_professor_creation -v 2`


------
https://chatgpt.com/codex/tasks/task_e_68a4c306cab0832a85262ce7040881dc