### PR TITLE
Standardize base URL usage in Postman collection

### DIFF
--- a/Unischedule API.postman_collection.json
+++ b/Unischedule API.postman_collection.json
@@ -1,323 +1,322 @@
 {
-	"info": {
-		"_postman_id": "5a6c01b8-640f-433b-a22c-47d0c1cd608a",
-		"name": "Unischedule API",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "34252406",
-		"_collection_link": "https://gold-equinox-965258.postman.co/workspace/Kheimatoshohada~649b2a82-f0c8-41a2-ad5c-60649bd44d7c/collection/34252406-5a6c01b8-640f-433b-a22c-47d0c1cd608a?action=share&source=collection_link&creator=34252406"
-	},
-	"item": [
-		{
-			"name": "Auth",
-			"item": [
-				{
-					"name": "Login",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "username",
-									"value": "erfan",
-									"type": "text"
-								},
-								{
-									"key": "password",
-									"value": "7634",
-									"type": "text"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{base_url}}api/auth/login/",
-							"host": [
-								"{{base_url}}api"
-							],
-							"path": [
-								"auth",
-								"login",
-								""
-							]
-						},
-						"description": "StartFragment\n\n# 📄 `POST - Login`\n\n**Folder:** `Auth/`  \n**Request Name:** `POST - Login`\n\n---\n\n## ✅ Description\n\nAuthenticate a user using username and password.  \n  \nReturns a valid **authentication token** if credentials are correct.\n\n---\n\n## 🔗 Endpoint\n\n```\nPOST {{base_url}}/api/auth/login/\n\n ```\n\n---\n\n## 🔐 Authentication\n\nNo authentication required.\n\n---\n\n## 📥 Request Body (JSON)\n\n| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n| `username` | string | ✅ | Username of the user |\n| `password` | string | ✅ | Password of the user |\n\n``` json\n{\n  \"username\": \"admin\",\n  \"password\": \"admin123\"\n}\n\n ```\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2000,\n  \"message\": \"ورود با موفقیت انجام شد.\",\n  \"data\": {\n    \"token\": \"8d2731b62fa3b25c952ad4b918d3d0ea9f3a7b1c\",\n    \"user\": {\n      \"id\": 1,\n      \"username\": \"admin\",\n      \"first_name\": \"Admin\",\n      \"last_name\": \"User\",\n      \"institution_id\": 2\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ Invalid Credentials\n\n**Status Code:** `401 UNAUTHORIZED`\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4101,\n  \"message\": \"نام کاربری یا رمز عبور نادرست است.\",\n  \"errors\": [\"Invalid username or password.\"],\n  \"data\": {}\n}\n\n ```\n\n### ❌ Validation Failed (Missing fields)\n\n**Status Code:** `400 BAD REQUEST`\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4102,\n  \"message\": \"خطای اعتبارسنجی ورودی‌ها.\",\n  \"errors\": {\n    \"username\": [\"This field is required.\"],\n    \"password\": [\"This field is required.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n### 💥 Internal Server Error\n\n**Status Code:** `500 INTERNAL SERVER ERROR`\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4500,\n  \"message\": \"ورود با خطا مواجه شد.\",\n  \"errors\": [\"Unhandled exception.\"],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid credentials provided\n    \n- **Then:** Token and user info returned\n    \n\n### ❌ Invalid Username or Password\n\n- **Then:** `401` with error code `4101`\n    \n\n### ❌ Missing Fields\n\n- **Then:** `400` with error code `4102`\n    \n\n### 💥 Server Error\n\n- **Then:** `500` with error code `4500`\n    \n\n---\n\n## 📌 Notes\n\n- The returned `token` must be used for subsequent authenticated requests:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🏷️ Tags\n\n`#Login` `#TokenAuth` `#Auth` `#POST`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **Serializer:** `LoginSerializer`\n    \n- **Service:** `login_user()`\n    \n- **View:** `login_view`\n    \n- **Token Model:** `rest_framework.authtoken.models.Token`\n    \n\nEndFragment"
-					},
-					"response": []
-				},
-				{
-					"name": "Logout",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}api/auth/logout/",
-							"host": [
-								"{{base_url}}api"
-							],
-							"path": [
-								"auth",
-								"logout",
-								""
-							]
-						},
-						"description": "---\n\n## 🔐 POST - Logout\n\n- **Purpose:** Logout the currently authenticated user by invalidating their token.\n    \n- **Method:** `POST`\n    \n- **URL:** `{{base_url}}/api/auth/logout/`\n    \n- **Authentication:** Required  \n      \n    Header: `Authorization: Token {{token}}`\n    \n\n---\n\n### 📥 Request\n\n#### Headers\n\n```\nAuthorization: Token {{token}}\nContent-Type: application/json\n\n ```\n\n#### Body\n\n_None_\n\n---\n\n### ✅ Success Response\n\n#### Status: `200 OK`\n\n``` json\n{\n  \"message\": \"Logout successful.\",\n  \"code\": 1201,\n  \"data\": {}\n}\n\n ```\n\n---\n\n### ❌ Error Responses\n\n#### 🔸 Token Not Found (User has no active token)\n\n``` json\n{\n  \"message\": \"Token not found for user.\",\n  \"code\": 4104,\n  \"errors\": {\n    \"non_field_errors\": [\"Token not found.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n#### 🔸 Unauthenticated (No token provided or invalid token)\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\nیا:\n\n``` json\n{\n  \"detail\": \"Invalid token.\"\n}\n\n ```\n\n---\n\n### 📘 Notes\n\n- This endpoint **removes the authenticated user's token**, effectively logging them out.\n    \n- If the user logs in again, a **new token** will be issued automatically.\n    \n- Best practice: call this on client logout action.\n    \n\nEndFragment"
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Semesters",
-			"item": [
-				{
-					"name": "List Semesters",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}api/semesters/",
-							"host": [
-								"{{base_url}}api"
-							],
-							"path": [
-								"semesters",
-								""
-							]
-						},
-						"description": "StartFragment\n\n### 📘 **GET - List Semesters**\n\n**Description**\n\nThis endpoint retrieves a list of all semesters related to the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nGET {{base_url}}/api/semesters/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nThis endpoint **requires token authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Query Parameters**\n\n_None_\n\n---\n\n### 📤 **Response (200 OK)**\n\n``` json\n{\n    \"success\": true,\n    \"code\": \"2101\",\n    \"message\": \"لیست ترم‌ها با موفقیت دریافت شد.\",\n    \"data\": {\n        \"semesters\": [\n            {\n                \"id\": 1,\n                \"title\": \"تابستان 3032\",\n                \"start_date\": \"2025-07-26\",\n                \"end_date\": \"2025-08-26\",\n                \"is_active\": true,\n                \"institution\": 1\n            }\n        ]\n    },\n    \"warnings\": [],\n    \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `401` | Authentication credentials were not provided. | 401 Unauthorized | Token is missing or invalid |\n| `403` | You do not have permission to perform this action. | 403 Forbidden | Token is valid but not allowed |\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Successful Request**: Authenticated user with valid token sees semesters of their institution.\n- ❌ **Unauthenticated Request**: No token → `401 Unauthorized`\n- ❌ **Invalid Token**: Token is invalid/expired → `401 Unauthorized`\n    \n\nEndFragment"
-					},
-					"response": []
-				},
-				{
-					"name": "Create Semester",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "title",
-									"value": "تابستان 4032",
-									"type": "text"
-								},
-								{
-									"key": "start_date",
-									"value": "2025-07-26",
-									"type": "text"
-								},
-								{
-									"key": "end_date",
-									"value": "2025-09-26",
-									"type": "text"
-								},
-								{
-									"key": "is_active",
-									"value": "False",
-									"type": "text"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{base_url}}/api/semesters/create/",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"semesters",
-								"create",
-								""
-							]
-						},
-						"description": "StartFragment\n\n### 🆕 **POST - Create Semester**\n\n**Description**\n\nCreates a new semester under the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nPOST {{base_url}}/api/semesters/create/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body** (JSON)\n\n``` json\n{\n    \"title\": \"تابستان 3032\",\n    \"start_date\": \"2025-07-26\",\n    \"end_date\": \"2025-08-26\"\n}\n\n ```\n\n---\n\n### 📤 **Success Response (201 Created)**\n\n``` json\n{\n    \"success\": true,\n    \"code\": \"2102\",\n    \"message\": \"ترم جدید با موفقیت ایجاد شد.\",\n    \"data\": {\n        \"semester\": {\n            \"id\": 2,\n            \"title\": \"تابستان 3032\",\n            \"start_date\": \"2025-07-26\",\n            \"end_date\": \"2025-08-26\",\n            \"is_active\": false,\n            \"institution\": 1\n        }\n    },\n    \"warnings\": [],\n    \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ **Possible Error Responses**\n\n#### 🔸 Validation Error (Invalid input data)\n\n``` json\n{\n    \"success\": false,\n    \"code\": \"4102\",\n    \"message\": \"اطلاعات وارد شده نامعتبر است.\",\n    \"errors\": {\n        \"title\": [\"This field is required.\"],\n        \"start_date\": [\"Enter a valid date.\"]\n    },\n    \"data\": {}\n}\n\n ```\n\n#### 🔸 General Creation Failure (Unexpected exception)\n\n``` json\n{\n    \"success\": false,\n    \"code\": \"4101\",\n    \"message\": \"ایجاد ترم با خطا مواجه شد.\",\n    \"errors\": [],\n    \"data\": {}\n}\n\n ```\n\n#### 🔸 Missing Token\n\n``` json\n{\n    \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid Request**: Valid data → Semester is created → `201 Created`\n- ❌ **Missing Token**: No `Authorization` header → `401 Unauthorized`\n- ❌ **Invalid Data**: Required fields missing → `400 Bad Request` with validation details\n- ❌ **Unexpected Error**: Internal error → `400 Bad Request` with general error message\n    \n\nEndFragment"
-					},
-					"response": []
-				},
-				{
-					"name": "Update Semester",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "title",
-									"value": "تست",
-									"type": "text"
-								},
-								{
-									"key": "start_date",
-									"value": "2025-07-26",
-									"type": "text"
-								},
-								{
-									"key": "end_date",
-									"value": "2025-07-29",
-									"type": "text"
-								},
-								{
-									"key": "is_active",
-									"value": "True",
-									"type": "text"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{base_url}}api/semesters/4/update/",
-							"host": [
-								"{{base_url}}api"
-							],
-							"path": [
-								"semesters",
-								"4",
-								"update",
-								""
-							]
-						},
-						"description": "StartFragment\n\n### 🆕 **PUT - Update Semester**\n\n**Description**\n\nUpdates an existing semester for the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nPUT {{base_url}}/api/semesters/<semester_id>/update/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body** (JSON)\n\n``` json\n{\n    \"title\": \"پاییز 3032\",\n    \"start_date\": \"2025-09-22\",\n    \"end_date\": \"2026-01-10\",\n    \"is_active\": true\n}\n\n ```\n\n> &lt;p &gt;All fields are optional but at least one must be provided.&lt;/p&gt; \n  \n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n    \"success\": true,\n    \"code\": \"2103\",\n    \"message\": \"ترم با موفقیت ویرایش شد.\",\n    \"data\": {\n        \"semester\": {\n            \"id\": 2,\n            \"title\": \"پاییز 3032\",\n            \"start_date\": \"2025-09-22\",\n            \"end_date\": \"2026-01-10\",\n            \"is_active\": true,\n            \"institution\": 1\n        }\n    },\n    \"warnings\": [],\n    \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4002` | اطلاعات وارد شده نامعتبر است. | 400 Bad Request | Validation error on request body fields |\n| `4103` | ویرایش ترم با خطا مواجه شد. | 500 Internal Error | Unexpected failure during update |\n| `401` | Authentication required | 401 Unauthorized | Missing or invalid token |\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid Update**: Valid fields provided → Semester is updated → 200\n- ❌ **Invalid Token**: Missing/invalid token → 401\n- ❌ **Invalid Input**: Wrong field format → 400\n- ❌ **Server Error**: Unexpected backend issue → 500\n    \n\nEndFragment"
-					},
-					"response": []
-				},
-				{
-					"name": "Delete Semester",
-					"request": {
-						"method": "DELETE",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}api/semesters/12/delete/",
-							"host": [
-								"{{base_url}}api"
-							],
-							"path": [
-								"semesters",
-								"12",
-								"delete",
-								""
-							]
-						},
-						"description": "StartFragment\n\n### 🆕 **DELETE - Delete Semester**\n\n**Description**\n\nSoft deletes a semester belonging to the authenticated user's institution. The record remains in the database but is marked as deleted.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nDELETE {{base_url}}/api/semesters/<semester_id>/delete/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body**\n\n_None_\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n    \"success\": true,\n    \"code\": \"2104\",\n    \"message\": \"ترم با موفقیت حذف شد.\",\n    \"data\": {},\n    \"warnings\": [],\n    \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4100` | ترم مورد نظر یافت نشد. | 404 Not Found | Semester not found for this institution |\n| `4104` | حذف ترم با خطا مواجه شد. | 500 Internal Error | Unexpected failure during deletion |\n| `401` | Authentication required | 401 Unauthorized | Missing or invalid token |\n\n#### 🔻 Example: Semester Not Found\n\n``` json\n{\n    \"success\": false,\n    \"message\": \"ترم مورد نظر یافت نشد.\",\n    \"code\": \"4100\",\n    \"errors\": [],\n    \"data\": {}\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid Deletion**: Semester exists → deletion succeeds → 200\n    \n- ❌ **Invalid ID**: Semester not found → 4100 (404)\n    \n- ❌ **Invalid Token**: Missing/invalid token → 401\n    \n- ❌ **Unexpected Error**: Internal issue in deletion logic → 4104 (500)\n    \n\nEndFragment"
-					},
-					"response": []
-				},
-				{
-					"name": "Set Active Semester",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "formdata",
-							"formdata": []
-						},
-						"url": {
-							"raw": "{{base_url}}api/semesters/11/activate/",
-							"host": [
-								"{{base_url}}api"
-							],
-							"path": [
-								"semesters",
-								"11",
-								"activate",
-								""
-							]
-						},
-						"description": "StartFragment\n\n### 🆕 **POST - Set Active Semester**\n\n**Description**\n\nActivates a semester for the current institution. When a semester is activated, all other semesters will automatically be deactivated.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nPOST {{base_url}}/api/semesters/<semester_id>/activate/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body**\n\n_None_\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n    \"success\": true,\n    \"code\": \"2105\",\n    \"message\": \"ترم فعال شد.\",\n    \"data\": {\n        \"semester\": {\n            \"id\": 1,\n            \"title\": \"پاییز 1403\",\n            \"start_date\": \"2024-09-23\",\n            \"end_date\": \"2025-01-20\",\n            \"is_active\": true,\n            \"institution\": 1\n        }\n    },\n    \"warnings\": [],\n    \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4100` | ترم مورد نظر یافت نشد. | 404 Not Found | Semester not found for this institution |\n| `4105` | فعال‌سازی ترم با خطا مواجه شد. | 500 Internal Error | Unexpected failure during activation |\n| `401` | Authentication required | 401 Unauthorized | Missing or invalid token |\n\n#### 🔻 Example: Semester Not Found\n\n``` json\n{\n    \"success\": false,\n    \"message\": \"ترم مورد نظر یافت نشد.\",\n    \"code\": \"4100\",\n    \"errors\": [],\n    \"data\": {}\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid Activation**: Semester exists → others deactivated → target semester activated → 200\n- ❌ **Invalid ID**: Semester not found → 4100 (404)\n- ❌ **Invalid Token**: Missing/invalid token → 401\n- ❌ **Unexpected Error**: Internal error during activation logic → 4105 (500)\n    \n\nEndFragment"
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Professors",
-			"item": [
-				{
-					"name": "List Professors",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}api/professors/",
-							"host": [
-								"{{base_url}}api"
-							],
-							"path": [
-								"professors",
-								""
-							]
-						},
-						"description": "StartFragment\n\n### 🆕 **GET - List Professors**\n\n**Description**\n\nRetrieves a list of all professors associated with the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nGET {{base_url}}/api/professors/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body**\n\n_None_\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n    \"success\": true,\n    \"code\": \"2201\",\n    \"message\": \"لیست اساتید با موفقیت دریافت شد.\",\n    \"data\": {\n        \"professors\": [\n            {\n                \"id\": 1,\n                \"first_name\": \"علی\",\n                \"last_name\": \"رضایی\",\n                \"national_code\": \"1234567890\",\n                \"phone_number\": \"09123456789\",\n                \"institution\": 1\n            }\n        ]\n    },\n    \"warnings\": [],\n    \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `401` | Authentication required | 401 Unauthorized | Missing or invalid token |\n| `4201` | دریافت لیست اساتید با خطا مواجه شد. | 500 Internal Error | Unexpected failure during listing |\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid Token**: Returns list of professors → 200\n    \n- ❌ **Missing Token**: Returns 401 Unauthorized\n    \n- ❌ **Unexpected Error**: Returns 4201 (500)\n    \n\nEndFragment"
-					},
-					"response": []
-				},
-				{
-					"name": "Retrieve Professor",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}api/professors/1/",
-							"host": [
-								"{{base_url}}api"
-							],
-							"path": [
-								"professors",
-								"1",
-								""
-							]
-						},
-						"description": "StartFragment\n\n### 🆕 **GET - Retrieve Professor**\n\n**Description**\n\nFetches details of a single professor by ID, scoped to the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nGET {{base_url}}/api/professors/<professor_id>/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body**\n\n_None_\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n    \"success\": true,\n    \"code\": \"2202\",\n    \"message\": \"اطلاعات استاد با موفقیت بازیابی شد.\",\n    \"data\": {\n        \"professor\": {\n            \"id\": 3,\n            \"first_name\": \"محمد\",\n            \"last_name\": \"صادقی\",\n            \"national_code\": \"1234567890\",\n            \"phone_number\": \"09121234567\",\n            \"institution\": 1\n        }\n    },\n    \"warnings\": [],\n    \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4200` | استاد مورد نظر یافت نشد. | 404 Not Found | Professor not found in institution |\n| `401` | Authentication required | 401 Unauthorized | Missing or invalid token |\n\n#### 🔻 Example: Professor Not Found\n\n``` json\n{\n    \"success\": false,\n    \"message\": \"استاد مورد نظر یافت نشد.\",\n    \"code\": \"4200\",\n    \"errors\": [],\n    \"data\": {}\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid Request**: Professor exists and belongs to the user's institution → 200\n    \n- ❌ **Invalid ID**: Professor with given ID not found → 4200 (404)\n    \n- ❌ **Invalid Token**: Missing/invalid token → 401\n    \n\nEndFragment"
-					},
-					"response": []
-				},
-				{
-					"name": "Create Professor",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "first_name",
-									"value": "عرفان",
-									"type": "text"
-								},
-								{
-									"key": "last_name",
-									"value": "رضایی2",
-									"type": "text"
-								},
-								{
-									"key": "national_code",
-									"value": "0912345677",
-									"type": "text"
-								},
-								{
-									"key": "phone_number",
-									"value": "09033483116",
-									"type": "text"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{base_url}}api/professors/create/",
-							"host": [
-								"{{base_url}}api"
-							],
-							"path": [
-								"professors",
-								"create",
-								""
-							]
-						},
-						"description": "StartFragment\n\n### 🆕 **POST - Create Professor**\n\n**Description**\n\nCreates a new professor under the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nPOST {{base_url}}/api/professors/create/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body (JSON)**\n\n``` json\n{\n  \"first_name\": \"علی\",\n  \"last_name\": \"احمدی\",\n  \"national_code\": \"1234567890\",\n  \"phone_number\": \"09121234567\"\n}\n\n ```\n\n| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n| `first_name` | string | ✅ | Professor's first name |\n| `last_name` | string | ✅ | Professor's last name |\n| `national_code` | string | ✅ | Unique national code |\n| `phone_number` | string | ❌ | Optional phone number |\n\n---\n\n### 📤 **Success Response (201 Created)**\n\n``` json\n{\n  \"success\": true,\n  \"code\": \"2201\",\n  \"message\": \"استاد جدید با موفقیت ایجاد شد.\",\n  \"data\": {\n    \"professor\": {\n      \"id\": 5,\n      \"first_name\": \"علی\",\n      \"last_name\": \"احمدی\",\n      \"national_code\": \"1234567890\",\n      \"phone_number\": \"09121234567\",\n      \"institution\": 1\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4102` | اطلاعات وارد شده نامعتبر است. | 400 Bad Request | Input validation failed |\n| `4201` | ایجاد استاد با خطا مواجه شد. | 500 Internal Error | Unhandled creation error |\n| `401` | Authentication credentials were not provided. | 401 Unauthorized | Token missing or invalid |\n\n#### 🔻 Example: Validation Error\n\n``` json\n{\n  \"success\": false,\n  \"message\": \"اطلاعات وارد شده نامعتبر است.\",\n  \"code\": \"4102\",\n  \"errors\": {\n    \"national_code\": [\"This field must be unique.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n#### 🔻 Example: Server Error\n\n``` json\n{\n  \"success\": false,\n  \"message\": \"ایجاد استاد با خطا مواجه شد.\",\n  \"code\": \"4201\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid Input** → Professor is created → `201 Created`\n    \n- ❌ **Missing or Duplicate National Code** → `4102` → Validation error\n    \n- ❌ **No token provided** → `401` → Unauthorized\n    \n- ❌ **Unhandled exception during creation** → `4201` → Server error\n    \n\nEndFragment"
-					},
-					"response": []
-				},
-				{
-					"name": "Update Professor",
+        "info": {
+                "_postman_id": "5a6c01b8-640f-433b-a22c-47d0c1cd608a",
+                "name": "Unischedule API",
+                "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+                "_exporter_id": "34252406",
+                "_collection_link": "https://gold-equinox-965258.postman.co/workspace/Kheimatoshohada~649b2a82-f0c8-41a2-ad5c-60649bd44d7c/collection/34252406-5a6c01b8-640f-433b-a22c-47d0c1cd608a?action=share&source=collection_link&creator=34252406"
+        },
+        "item": [
+                {
+                        "name": "Auth",
+                        "item": [
+                                {
+                                        "name": "Login",
+                                        "request": {
+                                                "method": "POST",
+                                                "header": [],
+                                                "body": {
+                                                        "mode": "formdata",
+                                                        "formdata": [
+                                                                {
+                                                                        "key": "username",
+                                                                        "value": "erfan",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "password",
+                                                                        "value": "7634",
+                                                                        "type": "text"
+                                                                }
+                                                        ]
+                                                },
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/auth/login/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "auth",
+                                                                "login"
+                                                        ]
+                                                },
+                                                "description": "StartFragment\n\n# 📄 `POST - Login`\n\n**Folder:** `Auth/`  \n**Request Name:** `POST - Login`\n\n---\n\n## ✅ Description\n\nAuthenticate a user using username and password.  \n  \nReturns a valid **authentication token** if credentials are correct.\n\n---\n\n## 🔗 Endpoint\n\n```\nPOST {{base_url}}/api/auth/login/\n\n ```\n\n---\n\n## 🔐 Authentication\n\nNo authentication required.\n\n---\n\n## 📥 Request Body (JSON)\n\n| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n| `username` | string | ✅ | Username of the user |\n| `password` | string | ✅ | Password of the user |\n\n``` json\n{\n  \"username\": \"admin\",\n  \"password\": \"admin123\"\n}\n\n ```\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2000,\n  \"message\": \"ورود با موفقیت انجام شد.\",\n  \"data\": {\n    \"token\": \"8d2731b62fa3b25c952ad4b918d3d0ea9f3a7b1c\",\n    \"user\": {\n      \"id\": 1,\n      \"username\": \"admin\",\n      \"first_name\": \"Admin\",\n      \"last_name\": \"User\",\n      \"institution_id\": 2\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ Invalid Credentials\n\n**Status Code:** `401 UNAUTHORIZED`\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4101,\n  \"message\": \"نام کاربری یا رمز عبور نادرست است.\",\n  \"errors\": [\"Invalid username or password.\"],\n  \"data\": {}\n}\n\n ```\n\n### ❌ Validation Failed (Missing fields)\n\n**Status Code:** `400 BAD REQUEST`\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4102,\n  \"message\": \"خطای اعتبارسنجی ورودی‌ها.\",\n  \"errors\": {\n    \"username\": [\"This field is required.\"],\n    \"password\": [\"This field is required.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n### 💥 Internal Server Error\n\n**Status Code:** `500 INTERNAL SERVER ERROR`\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4500,\n  \"message\": \"ورود با خطا مواجه شد.\",\n  \"errors\": [\"Unhandled exception.\"],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid credentials provided\n    \n- **Then:** Token and user info returned\n    \n\n### ❌ Invalid Username or Password\n\n- **Then:** `401` with error code `4101`\n    \n\n### ❌ Missing Fields\n\n- **Then:** `400` with error code `4102`\n    \n\n### 💥 Server Error\n\n- **Then:** `500` with error code `4500`\n    \n\n---\n\n## 📌 Notes\n\n- The returned `token` must be used for subsequent authenticated requests:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🏷️ Tags\n\n`#Login` `#TokenAuth` `#Auth` `#POST`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **Serializer:** `LoginSerializer`\n    \n- **Service:** `login_user()`\n    \n- **View:** `login_view`\n    \n- **Token Model:** `rest_framework.authtoken.models.Token`\n    \n\nEndFragment"
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "Logout",
+                                        "request": {
+                                                "method": "POST",
+                                                "header": [],
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/auth/logout/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "auth",
+                                                                "logout"
+                                                        ]
+                                                },
+                                                "description": "---\n\n## 🔐 POST - Logout\n\n- **Purpose:** Logout the currently authenticated user by invalidating their token.\n    \n- **Method:** `POST`\n    \n- **URL:** `{{base_url}}/api/auth/logout/`\n    \n- **Authentication:** Required  \n      \n    Header: `Authorization: Token {{token}}`\n    \n\n---\n\n### 📥 Request\n\n#### Headers\n\n```\nAuthorization: Token {{token}}\nContent-Type: application/json\n\n ```\n\n#### Body\n\n_None_\n\n---\n\n### ✅ Success Response\n\n#### Status: `200 OK`\n\n``` json\n{\n  \"message\": \"Logout successful.\",\n  \"code\": 1201,\n  \"data\": {}\n}\n\n ```\n\n---\n\n### ❌ Error Responses\n\n#### 🔸 Token Not Found (User has no active token)\n\n``` json\n{\n  \"message\": \"Token not found for user.\",\n  \"code\": 4104,\n  \"errors\": {\n    \"non_field_errors\": [\"Token not found.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n#### 🔸 Unauthenticated (No token provided or invalid token)\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\nیا:\n\n``` json\n{\n  \"detail\": \"Invalid token.\"\n}\n\n ```\n\n---\n\n### 📘 Notes\n\n- This endpoint **removes the authenticated user's token**, effectively logging them out.\n    \n- If the user logs in again, a **new token** will be issued automatically.\n    \n- Best practice: call this on client logout action.\n    \n\nEndFragment"
+                                        },
+                                        "response": []
+                                }
+                        ]
+                },
+                {
+                        "name": "Semesters",
+                        "item": [
+                                {
+                                        "name": "List Semesters",
+                                        "request": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/semesters/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "semesters"
+                                                        ]
+                                                },
+                                                "description": "StartFragment\n\n### 📘 **GET - List Semesters**\n\n**Description**\n\nThis endpoint retrieves a list of all semesters related to the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nGET {{base_url}}/api/semesters/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nThis endpoint **requires token authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Query Parameters**\n\n_None_\n\n---\n\n### 📤 **Response (200 OK)**\n\n``` json\n{\n    \"success\": true,\n    \"code\": \"2101\",\n    \"message\": \"لیست ترم‌ها با موفقیت دریافت شد.\",\n    \"data\": {\n        \"semesters\": [\n            {\n                \"id\": 1,\n                \"title\": \"تابستان 3032\",\n                \"start_date\": \"2025-07-26\",\n                \"end_date\": \"2025-08-26\",\n                \"is_active\": true,\n                \"institution\": 1\n            }\n        ]\n    },\n    \"warnings\": [],\n    \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `401` | Authentication credentials were not provided. | 401 Unauthorized | Token is missing or invalid |\n| `403` | You do not have permission to perform this action. | 403 Forbidden | Token is valid but not allowed |\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Successful Request**: Authenticated user with valid token sees semesters of their institution.\n- ❌ **Unauthenticated Request**: No token → `401 Unauthorized`\n- ❌ **Invalid Token**: Token is invalid/expired → `401 Unauthorized`\n    \n\nEndFragment"
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "Create Semester",
+                                        "request": {
+                                                "method": "POST",
+                                                "header": [],
+                                                "body": {
+                                                        "mode": "formdata",
+                                                        "formdata": [
+                                                                {
+                                                                        "key": "title",
+                                                                        "value": "تابستان 4032",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "start_date",
+                                                                        "value": "2025-07-26",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "end_date",
+                                                                        "value": "2025-09-26",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "is_active",
+                                                                        "value": "False",
+                                                                        "type": "text"
+                                                                }
+                                                        ]
+                                                },
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/semesters/create/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "semesters",
+                                                                "create"
+                                                        ]
+                                                },
+                                                "description": "StartFragment\n\n### 🆕 **POST - Create Semester**\n\n**Description**\n\nCreates a new semester under the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nPOST {{base_url}}/api/semesters/create/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body** (JSON)\n\n``` json\n{\n    \"title\": \"تابستان 3032\",\n    \"start_date\": \"2025-07-26\",\n    \"end_date\": \"2025-08-26\"\n}\n\n ```\n\n---\n\n### 📤 **Success Response (201 Created)**\n\n``` json\n{\n    \"success\": true,\n    \"code\": \"2102\",\n    \"message\": \"ترم جدید با موفقیت ایجاد شد.\",\n    \"data\": {\n        \"semester\": {\n            \"id\": 2,\n            \"title\": \"تابستان 3032\",\n            \"start_date\": \"2025-07-26\",\n            \"end_date\": \"2025-08-26\",\n            \"is_active\": false,\n            \"institution\": 1\n        }\n    },\n    \"warnings\": [],\n    \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ **Possible Error Responses**\n\n#### 🔸 Validation Error (Invalid input data)\n\n``` json\n{\n    \"success\": false,\n    \"code\": \"4102\",\n    \"message\": \"اطلاعات وارد شده نامعتبر است.\",\n    \"errors\": {\n        \"title\": [\"This field is required.\"],\n        \"start_date\": [\"Enter a valid date.\"]\n    },\n    \"data\": {}\n}\n\n ```\n\n#### 🔸 General Creation Failure (Unexpected exception)\n\n``` json\n{\n    \"success\": false,\n    \"code\": \"4101\",\n    \"message\": \"ایجاد ترم با خطا مواجه شد.\",\n    \"errors\": [],\n    \"data\": {}\n}\n\n ```\n\n#### 🔸 Missing Token\n\n``` json\n{\n    \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid Request**: Valid data → Semester is created → `201 Created`\n- ❌ **Missing Token**: No `Authorization` header → `401 Unauthorized`\n- ❌ **Invalid Data**: Required fields missing → `400 Bad Request` with validation details\n- ❌ **Unexpected Error**: Internal error → `400 Bad Request` with general error message\n    \n\nEndFragment"
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "Update Semester",
+                                        "request": {
+                                                "method": "PUT",
+                                                "header": [],
+                                                "body": {
+                                                        "mode": "formdata",
+                                                        "formdata": [
+                                                                {
+                                                                        "key": "title",
+                                                                        "value": "تست",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "start_date",
+                                                                        "value": "2025-07-26",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "end_date",
+                                                                        "value": "2025-07-29",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "is_active",
+                                                                        "value": "True",
+                                                                        "type": "text"
+                                                                }
+                                                        ]
+                                                },
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/semesters/4/update/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "semesters",
+                                                                "4",
+                                                                "update"
+                                                        ]
+                                                },
+                                                "description": "StartFragment\n\n### 🆕 **PUT - Update Semester**\n\n**Description**\n\nUpdates an existing semester for the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nPUT {{base_url}}/api/semesters/<semester_id>/update/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body** (JSON)\n\n``` json\n{\n    \"title\": \"پاییز 3032\",\n    \"start_date\": \"2025-09-22\",\n    \"end_date\": \"2026-01-10\",\n    \"is_active\": true\n}\n\n ```\n\n> &lt;p &gt;All fields are optional but at least one must be provided.&lt;/p&gt; \n  \n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n    \"success\": true,\n    \"code\": \"2103\",\n    \"message\": \"ترم با موفقیت ویرایش شد.\",\n    \"data\": {\n        \"semester\": {\n            \"id\": 2,\n            \"title\": \"پاییز 3032\",\n            \"start_date\": \"2025-09-22\",\n            \"end_date\": \"2026-01-10\",\n            \"is_active\": true,\n            \"institution\": 1\n        }\n    },\n    \"warnings\": [],\n    \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4002` | اطلاعات وارد شده نامعتبر است. | 400 Bad Request | Validation error on request body fields |\n| `4103` | ویرایش ترم با خطا مواجه شد. | 500 Internal Error | Unexpected failure during update |\n| `401` | Authentication required | 401 Unauthorized | Missing or invalid token |\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid Update**: Valid fields provided → Semester is updated → 200\n- ❌ **Invalid Token**: Missing/invalid token → 401\n- ❌ **Invalid Input**: Wrong field format → 400\n- ❌ **Server Error**: Unexpected backend issue → 500\n    \n\nEndFragment"
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "Delete Semester",
+                                        "request": {
+                                                "method": "DELETE",
+                                                "header": [],
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/semesters/12/delete/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "semesters",
+                                                                "12",
+                                                                "delete"
+                                                        ]
+                                                },
+                                                "description": "StartFragment\n\n### 🆕 **DELETE - Delete Semester**\n\n**Description**\n\nSoft deletes a semester belonging to the authenticated user's institution. The record remains in the database but is marked as deleted.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nDELETE {{base_url}}/api/semesters/<semester_id>/delete/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body**\n\n_None_\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n    \"success\": true,\n    \"code\": \"2104\",\n    \"message\": \"ترم با موفقیت حذف شد.\",\n    \"data\": {},\n    \"warnings\": [],\n    \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4100` | ترم مورد نظر یافت نشد. | 404 Not Found | Semester not found for this institution |\n| `4104` | حذف ترم با خطا مواجه شد. | 500 Internal Error | Unexpected failure during deletion |\n| `401` | Authentication required | 401 Unauthorized | Missing or invalid token |\n\n#### 🔻 Example: Semester Not Found\n\n``` json\n{\n    \"success\": false,\n    \"message\": \"ترم مورد نظر یافت نشد.\",\n    \"code\": \"4100\",\n    \"errors\": [],\n    \"data\": {}\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid Deletion**: Semester exists → deletion succeeds → 200\n    \n- ❌ **Invalid ID**: Semester not found → 4100 (404)\n    \n- ❌ **Invalid Token**: Missing/invalid token → 401\n    \n- ❌ **Unexpected Error**: Internal issue in deletion logic → 4104 (500)\n    \n\nEndFragment"
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "Set Active Semester",
+                                        "request": {
+                                                "method": "POST",
+                                                "header": [],
+                                                "body": {
+                                                        "mode": "formdata",
+                                                        "formdata": []
+                                                },
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/semesters/11/activate/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "semesters",
+                                                                "11",
+                                                                "activate"
+                                                        ]
+                                                },
+                                                "description": "StartFragment\n\n### 🆕 **POST - Set Active Semester**\n\n**Description**\n\nActivates a semester for the current institution. When a semester is activated, all other semesters will automatically be deactivated.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nPOST {{base_url}}/api/semesters/<semester_id>/activate/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body**\n\n_None_\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n    \"success\": true,\n    \"code\": \"2105\",\n    \"message\": \"ترم فعال شد.\",\n    \"data\": {\n        \"semester\": {\n            \"id\": 1,\n            \"title\": \"پاییز 1403\",\n            \"start_date\": \"2024-09-23\",\n            \"end_date\": \"2025-01-20\",\n            \"is_active\": true,\n            \"institution\": 1\n        }\n    },\n    \"warnings\": [],\n    \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4100` | ترم مورد نظر یافت نشد. | 404 Not Found | Semester not found for this institution |\n| `4105` | فعال‌سازی ترم با خطا مواجه شد. | 500 Internal Error | Unexpected failure during activation |\n| `401` | Authentication required | 401 Unauthorized | Missing or invalid token |\n\n#### 🔻 Example: Semester Not Found\n\n``` json\n{\n    \"success\": false,\n    \"message\": \"ترم مورد نظر یافت نشد.\",\n    \"code\": \"4100\",\n    \"errors\": [],\n    \"data\": {}\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid Activation**: Semester exists → others deactivated → target semester activated → 200\n- ❌ **Invalid ID**: Semester not found → 4100 (404)\n- ❌ **Invalid Token**: Missing/invalid token → 401\n- ❌ **Unexpected Error**: Internal error during activation logic → 4105 (500)\n    \n\nEndFragment"
+                                        },
+                                        "response": []
+                                }
+                        ]
+                },
+                {
+                        "name": "Professors",
+                        "item": [
+                                {
+                                        "name": "List Professors",
+                                        "request": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/professors/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "professors"
+                                                        ]
+                                                },
+                                                "description": "StartFragment\n\n### 🆕 **GET - List Professors**\n\n**Description**\n\nRetrieves a list of all professors associated with the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nGET {{base_url}}/api/professors/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body**\n\n_None_\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n    \"success\": true,\n    \"code\": \"2201\",\n    \"message\": \"لیست اساتید با موفقیت دریافت شد.\",\n    \"data\": {\n        \"professors\": [\n            {\n                \"id\": 1,\n                \"first_name\": \"علی\",\n                \"last_name\": \"رضایی\",\n                \"national_code\": \"1234567890\",\n                \"phone_number\": \"09123456789\",\n                \"institution\": 1\n            }\n        ]\n    },\n    \"warnings\": [],\n    \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `401` | Authentication required | 401 Unauthorized | Missing or invalid token |\n| `4201` | دریافت لیست اساتید با خطا مواجه شد. | 500 Internal Error | Unexpected failure during listing |\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid Token**: Returns list of professors → 200\n    \n- ❌ **Missing Token**: Returns 401 Unauthorized\n    \n- ❌ **Unexpected Error**: Returns 4201 (500)\n    \n\nEndFragment"
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "Retrieve Professor",
+                                        "request": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/professors/1/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "professors",
+                                                                "1"
+                                                        ]
+                                                },
+                                                "description": "StartFragment\n\n### 🆕 **GET - Retrieve Professor**\n\n**Description**\n\nFetches details of a single professor by ID, scoped to the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nGET {{base_url}}/api/professors/<professor_id>/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body**\n\n_None_\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n    \"success\": true,\n    \"code\": \"2202\",\n    \"message\": \"اطلاعات استاد با موفقیت بازیابی شد.\",\n    \"data\": {\n        \"professor\": {\n            \"id\": 3,\n            \"first_name\": \"محمد\",\n            \"last_name\": \"صادقی\",\n            \"national_code\": \"1234567890\",\n            \"phone_number\": \"09121234567\",\n            \"institution\": 1\n        }\n    },\n    \"warnings\": [],\n    \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4200` | استاد مورد نظر یافت نشد. | 404 Not Found | Professor not found in institution |\n| `401` | Authentication required | 401 Unauthorized | Missing or invalid token |\n\n#### 🔻 Example: Professor Not Found\n\n``` json\n{\n    \"success\": false,\n    \"message\": \"استاد مورد نظر یافت نشد.\",\n    \"code\": \"4200\",\n    \"errors\": [],\n    \"data\": {}\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid Request**: Professor exists and belongs to the user's institution → 200\n    \n- ❌ **Invalid ID**: Professor with given ID not found → 4200 (404)\n    \n- ❌ **Invalid Token**: Missing/invalid token → 401\n    \n\nEndFragment"
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "Create Professor",
+                                        "request": {
+                                                "method": "POST",
+                                                "header": [],
+                                                "body": {
+                                                        "mode": "formdata",
+                                                        "formdata": [
+                                                                {
+                                                                        "key": "first_name",
+                                                                        "value": "عرفان",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "last_name",
+                                                                        "value": "رضایی2",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "national_code",
+                                                                        "value": "0912345677",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "phone_number",
+                                                                        "value": "09033483116",
+                                                                        "type": "text"
+                                                                }
+                                                        ]
+                                                },
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/professors/create/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "professors",
+                                                                "create"
+                                                        ]
+                                                },
+                                                "description": "StartFragment\n\n### 🆕 **POST - Create Professor**\n\n**Description**\n\nCreates a new professor under the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nPOST {{base_url}}/api/professors/create/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body (JSON)**\n\n``` json\n{\n  \"first_name\": \"علی\",\n  \"last_name\": \"احمدی\",\n  \"national_code\": \"1234567890\",\n  \"phone_number\": \"09121234567\"\n}\n\n ```\n\n| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n| `first_name` | string | ✅ | Professor's first name |\n| `last_name` | string | ✅ | Professor's last name |\n| `national_code` | string | ✅ | Unique national code |\n| `phone_number` | string | ❌ | Optional phone number |\n\n---\n\n### 📤 **Success Response (201 Created)**\n\n``` json\n{\n  \"success\": true,\n  \"code\": \"2201\",\n  \"message\": \"استاد جدید با موفقیت ایجاد شد.\",\n  \"data\": {\n    \"professor\": {\n      \"id\": 5,\n      \"first_name\": \"علی\",\n      \"last_name\": \"احمدی\",\n      \"national_code\": \"1234567890\",\n      \"phone_number\": \"09121234567\",\n      \"institution\": 1\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4102` | اطلاعات وارد شده نامعتبر است. | 400 Bad Request | Input validation failed |\n| `4201` | ایجاد استاد با خطا مواجه شد. | 500 Internal Error | Unhandled creation error |\n| `401` | Authentication credentials were not provided. | 401 Unauthorized | Token missing or invalid |\n\n#### 🔻 Example: Validation Error\n\n``` json\n{\n  \"success\": false,\n  \"message\": \"اطلاعات وارد شده نامعتبر است.\",\n  \"code\": \"4102\",\n  \"errors\": {\n    \"national_code\": [\"This field must be unique.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n#### 🔻 Example: Server Error\n\n``` json\n{\n  \"success\": false,\n  \"message\": \"ایجاد استاد با خطا مواجه شد.\",\n  \"code\": \"4201\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid Input** → Professor is created → `201 Created`\n    \n- ❌ **Missing or Duplicate National Code** → `4102` → Validation error\n    \n- ❌ **No token provided** → `401` → Unauthorized\n    \n- ❌ **Unhandled exception during creation** → `4201` → Server error\n    \n\nEndFragment"
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "Update Professor",
                                         "request": {
                                                 "method": "PUT",
                                                 "header": [
@@ -351,539 +350,526 @@
                                                                 "update"
                                                         ]
                                                 },
-						"description": "StartFragment\n\n### 🟡 PUT - Update Professor\n\n**Endpoint:**\n\n```\nPUT api/professors/:id/update/\n\n ```\n\n**Description:**\n\nUpdate an existing professor's profile (first name, last name, or phone number) in the authenticated user's institution.\n\n---\n\n### 🔐 Authorization\n\n- Required: ✅ Yes\n    \n- Type: Bearer Token (use `{{token}}` in environment)\n    \n\n---\n\n### 📥 Request Parameters\n\n#### 🔹 Path Parameters:\n\n| Param | Type | Required | Description |\n| --- | --- | --- | --- |\n| id | int | ✅ | ID of the professor to update |\n\n#### 🔸 Body (JSON):\n\n``` json\n{\n  \"first_name\": \"Ali\",\n  \"last_name\": \"Ahmadi\",\n  \"phone_number\": \"09123456789\"\n}\n\n ```\n\n- All fields are optional (partial update supported)\n    \n- If field is not included, it will remain unchanged.\n    \n\n---\n\n### 📤 Success Response (200 OK)\n\n``` json\n{\n  \"status\": true,\n  \"code\": \"PROFESSOR_UPDATED\",\n  \"message\": \"Professor updated successfully.\",\n  \"data\": {\n    \"professor\": {\n      \"id\": 5,\n      \"first_name\": \"Ali\",\n      \"last_name\": \"Ahmadi\",\n      \"national_code\": \"0076543210\",\n      \"phone_number\": \"09123456789\",\n      \"institution\": 1\n    }\n  }\n}\n\n ```\n\n---\n\n### ❌ Error Responses\n\n#### 🔸 404 - Professor Not Found\n\n``` json\n{\n  \"status\": false,\n  \"code\": \"PROFESSOR_NOT_FOUND\",\n  \"message\": \"Professor not found.\",\n  \"errors\": {},\n  \"data\": null\n}\n\n ```\n\n#### 🔸 400 - Validation Error\n\n``` json\n{\n  \"status\": false,\n  \"code\": \"VALIDATION_FAILED\",\n  \"message\": \"Validation failed.\",\n  \"errors\": {\n    \"phone_number\": [\"Enter a valid phone number.\"]\n  },\n  \"data\": null\n}\n\n ```\n\n#### 🔸 500 - Update Failed\n\n``` json\n{\n  \"status\": false,\n  \"code\": \"PROFESSOR_UPDATE_FAILED\",\n  \"message\": \"Could not update professor.\",\n  \"errors\": {},\n  \"data\": null\n}\n\n ```\n\n---\n\n### 🧠 Notes\n\n- Fields are partially updatable (no need to send all fields).\n    \n- If professor with given ID doesn't exist or doesn't belong to the user's institution, 404 will be returned.\n    \n- All validation errors return `4102` project-specific code (`VALIDATION_FAILED`).\n    \n- Uses standard `BaseResponse` structure.\n    \n\n---\n\n### 📁 Folder in Postman\n\n```\nProfessors/\n  └── PUT - Update\n\n ```\n\n### 🔧 Environment Variables Required\n\n- `{{base_url}}`\n    \n- `{{token}}`\n    \n\nEndFragment"
-					},
-					"response": []
-				},
-				{
-					"name": "Delete Professor",
-					"request": {
-						"method": "DELETE",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}api/professors/1/delete/",
-							"host": [
-								"{{base_url}}api"
-							],
-							"path": [
-								"professors",
-								"1",
-								"delete",
-								""
-							]
-						},
-						"description": "StartFragment\n\n### ❌ **DELETE - Delete Professor**\n\n**Description**\n\nSoft deletes a professor by ID from the authenticated user's institution. The professor will remain in the database but marked as deleted.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nDELETE {{base_url}}/api/professors/<professor_id>/delete/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Path Parameters**\n\n| Parameter | Type | Required | Description |\n| --- | --- | --- | --- |\n| `professor_id` | int | ✅ | ID of the professor to be deleted |\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n  \"success\": true,\n  \"code\": \"2203\",\n  \"message\": \"استاد با موفقیت حذف شد.\",\n  \"data\": {},\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4100` | ترم مورد نظر یافت نشد. | 404 Not Found | If the professor with the given ID does not exist or does not belong to the institution |\n| `4203` | حذف استاد با خطا مواجه شد. | 500 Internal Error | Unexpected server-side error during deletion |\n| `401` | Authentication credentials were not provided. | 401 Unauthorized | Token missing or invalid |\n\n#### 🔻 Example: Professor Not Found\n\n``` json\n{\n  \"success\": false,\n  \"message\": \"استاد مورد نظر یافت نشد.\",\n  \"code\": \"4100\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n#### 🔻 Example: Server Error\n\n``` json\n{\n  \"success\": false,\n  \"message\": \"حذف استاد با خطا مواجه شد.\",\n  \"code\": \"4203\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid ID** → Professor is soft deleted → `200 OK`\n    \n- ❌ **Invalid or non-existent ID** → `4100`\n    \n- ❌ **No token provided** → `401 Unauthorized`\n    \n- ❌ **Server crash** → `4203`\n    \n\nEndFragment"
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Courses",
-			"item": [
-				{
-					"name": "List Courses",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}api/courses/",
-							"host": [
-								"{{base_url}}api"
-							],
-							"path": [
-								"courses",
-								""
-							]
-						},
-						"description": "StartFragment\n\n### 📄 **GET - List Courses**\n\n**Description**\n\nدریافت لیست تمام درس‌هایی که متعلق به موسسه کاربر احراز هویت شده هستند.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nGET {{base_url}}/api/courses/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n  \"success\": true,\n  \"code\": \"2301\",\n  \"message\": \"لیست درس‌ها با موفقیت دریافت شد.\",\n  \"data\": {\n    \"courses\": [\n      {\n        \"id\": 1,\n        \"code\": \"ISLAM101\",\n        \"title\": \"اندیشه اسلامی 1\",\n        \"professor\": 3,\n        \"offer_code\": \"1404-1-IS101-A\",\n        \"unit_count\": 3,\n        \"is_active\": true\n      }\n    ]\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `401` | Authentication credentials were not provided. | 401 Unauthorized | توکن ارائه نشده یا معتبر نیست |\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **کاربر احراز شده** → لیست دروس را دریافت می‌کند → `200 OK`\n- ❌ **کاربر بدون توکن** → `401 Unauthorized`\n    \n\nEndFragment"
-					},
-					"response": []
-				},
-				{
-					"name": "Retrieve Course",
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}api/courses/1/",
-							"host": [
-								"{{base_url}}api"
-							],
-							"path": [
-								"courses",
-								"1",
-								""
-							]
-						},
-						"description": "StartFragment\n\n### 🔍 **GET - Retrieve Course**\n\n**Description**\n\nRetrieves a single course by ID for the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nGET {{base_url}}/api/courses/<course_id>/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n  \"success\": true,\n  \"code\": \"2302\",\n  \"message\": \"Course retrieved successfully.\",\n  \"data\": {\n    \"course\": {\n      \"id\": 2,\n      \"title\": \"تفکر اسلامی\",\n      \"code\": \"ISLAM101\",\n      \"offer_code\": \"1404-1-IS101-B\",\n      \"unit_count\": 3,\n      \"is_active\": true,\n      \"professor\": 7,\n      \"institution\": 1\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4300` | درس مورد نظر یافت نشد. | 404 Not Found | Course not found or does not belong to user |\n| `401` | Authentication credentials were not provided. | 401 Unauthorized | Token missing or invalid |\n\n#### 🔻 Example: Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": \"4300\",\n  \"message\": \"درس مورد نظر یافت نشد.\",\n  \"data\": {},\n  \"errors\": []\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid course ID** → Course returned successfully → `200 OK`\n    \n- ❌ **Invalid or inaccessible course ID** → `4300` → Not Found\n    \n- ❌ **Missing token** → `401` → Unauthorized\n    \n\nEndFragment"
-					},
-					"response": []
-				},
-				{
-					"name": "Create Course",
-					"request": {
-						"method": "POST",
-						"header": [],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "title",
-									"value": "زبان",
-									"type": "text"
-								},
-								{
-									"key": "code",
-									"value": "1010",
-									"type": "text"
-								},
-								{
-									"key": "offer_code",
-									"value": "1012",
-									"type": "text"
-								},
-								{
-									"key": "unit_count",
-									"value": "3",
-									"type": "text"
-								},
-								{
-									"key": "is_active",
-									"value": "True",
-									"type": "text"
-								},
-								{
-									"key": "professor",
-									"value": "2",
-									"type": "text"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{base_url}}api/courses/create/",
-							"host": [
-								"{{base_url}}api"
-							],
-							"path": [
-								"courses",
-								"create",
-								""
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Update Course",
-					"request": {
-						"method": "PUT",
-						"header": [],
-						"body": {
-							"mode": "formdata",
-							"formdata": [
-								{
-									"key": "title",
-									"value": "انگلیسی",
-									"type": "text"
-								},
-								{
-									"key": "unit_count",
-									"value": "",
-									"type": "text"
-								},
-								{
-									"key": "is_active",
-									"value": "",
-									"type": "text"
-								},
-								{
-									"key": "professor",
-									"value": "",
-									"type": "text"
-								}
-							]
-						},
-						"url": {
-							"raw": "{{base_url}}/api/courses/2/update/",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"courses",
-								"2",
-								"update",
-								""
-							]
-						},
-						"description": "StartFragment\n\n### 🆕 **PUT - Update Course**\n\n**Description**  \n  \nUpdates an existing course under the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nPUT {{base_url}}/api/courses/<course_id>/update/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body (JSON)**\n\n``` json\n{\n  \"title\": \"اندیشه اسلامی ۱ - ویرایش شده\",\n  \"unit_count\": 2,\n  \"is_active\": false,\n  \"professor\": 4\n}\n\n ```\n\n| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n| `title` | string | ❌ | New title for the course |\n| `unit_count` | int | ❌ | Updated unit count (defaults to 3) |\n| `is_active` | bool | ❌ | Whether course is currently active |\n| `professor` | int | ❌ | ID of the updated professor (if changed) |\n\nNote: Fields are optional; only provided fields will be updated.\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n  \"success\": true,\n  \"code\": \"2302\",\n  \"message\": \"اطلاعات درس با موفقیت به‌روزرسانی شد.\",\n  \"data\": {\n    \"course\": {\n      \"id\": 9,\n      \"title\": \"اندیشه اسلامی ۱ - ویرایش شده\",\n      \"code\": \"ISLAM101\",\n      \"offer_code\": \"1404-1-IS101-X\",\n      \"unit_count\": 2,\n      \"is_active\": false,\n      \"professor\": 4,\n      \"institution\": 1\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4102` | اطلاعات وارد شده نامعتبر است. | 400 Bad Request | Validation failed |\n| `4302` | به‌روزرسانی اطلاعات درس با خطا مواجه شد. | 500 Internal Error | Server-side error during update |\n| `4100` | درس مورد نظر یافت نشد. | 404 Not Found | Invalid `course_id` or unauthorized access |\n| `401` | Authentication credentials were not provided. | 401 Unauthorized | Missing/invalid token |\n\n#### 🔻 Example: Validation Error (Invalid unit count)\n\n``` json\n{\n  \"success\": false,\n  \"code\": \"4102\",\n  \"message\": \"اطلاعات وارد شده نامعتبر است.\",\n  \"errors\": {\n    \"unit_count\": [\"Ensure this value is greater than or equal to 1.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n#### 🔻 Example: Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": \"4100\",\n  \"message\": \"درس مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n#### 🔻 Example: Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": \"4302\",\n  \"message\": \"به‌روزرسانی اطلاعات درس با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Partial update (only title)** → `200 OK`\n    \n- ❌ **Invalid field value (e.g. unit_count < 1)** → `4102`\n    \n- ❌ **Unauthorized access** → `401`\n    \n- ❌ **Course not found** → `4100`\n    \n- ❌ **Unhandled server error** → `4302`\n    \n\nEndFragment"
-					},
-					"response": []
-				},
-				{
-					"name": "Delete Course",
-					"request": {
-						"method": "DELETE",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}/api/courses/2/delete/",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"api",
-								"courses",
-								"2",
-								"delete",
-								""
-							]
-						},
-						"description": "StartFragment\n\n---\n\n### ❌ **DELETE - Delete Course**\n\n**Description**\n\nSoft deletes a course (without permanent removal) by setting `is_deleted=True`. Only accessible to users within the same institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nDELETE {{base_url}}/api/courses/<course_id>/delete/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Parameters**\n\n| Param | In | Type | Required | Description |\n| --- | --- | --- | --- | --- |\n| `course_id` | path | int | ✅ | ID of the course to be deleted |\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n  \"success\": true,\n  \"code\": \"2303\",\n  \"message\": \"درس با موفقیت حذف شد.\",\n  \"data\": {},\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4100` | درس مورد نظر یافت نشد. | 404 Not Found | Invalid `course_id` or unauthorized access |\n| `4303` | حذف درس با خطا مواجه شد. | 500 Internal Error | Unhandled server error during deletion |\n| `401` | Authentication credentials were not provided. | 401 Unauthorized | Missing or invalid token |\n\n#### 🔻 Example: Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": \"4100\",\n  \"message\": \"درس مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n#### 🔻 Example: Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": \"4303\",\n  \"message\": \"حذف درس با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid course ID in user’s institution** → `200 OK`\n    \n- ❌ **Invalid course ID** → `4100`\n    \n- ❌ **Unauthorized request** → `401`\n    \n- ❌ **Server error** → `4303`\n    \n\n---\n\nEndFragment"
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Locations",
-			"item": [
-				{
-					"name": "Buildings",
-					"item": [
-						{
-							"name": "List Buildings",
-							"request": {
-								"method": "GET",
-								"header": [],
-								"url": {
-									"raw": "{{base_url}}/api/locations/buildings/",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"api",
-										"locations",
-										"buildings",
-										""
-									]
-								},
-								"description": "StartFragment\n\n# 📄 `GET - List Buildings`\n\n**Folder:** `Buildings/`  \n**Request Name:** `GET - List Buildings`\n\n---\n\n## ✅ Description\n\nReturns all buildings for the authenticated user's institution. Only buildings that are not soft-deleted (`is_deleted = False`) will be returned.\n\n---\n\n## 🔗 Endpoint\n\n```\nGET {{base_url}}/api/locations/buildings/\n\n ```\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 📥 Request Body\n\n_None_\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2500,\n  \"message\": \"لیست ساختمان‌ها با موفقیت دریافت شد.\",\n  \"data\": {\n    \"buildings\": [\n      {\n        \"id\": 1,\n        \"title\": \"ساختمان شماره یک\",\n        \"institution\": 3\n      },\n      {\n        \"id\": 2,\n        \"title\": \"دانشکده علوم پایه\",\n        \"institution\": 3\n      }\n    ]\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### 🔒 401 Unauthorized - Missing Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 🔒 401 Unauthorized - Invalid Token\n\n``` json\n{\n  \"detail\": \"Invalid token.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4500,\n  \"message\": \"دریافت لیست ساختمان‌ها با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token and buildings exist\n    \n- **Then:** Returns 200 with list of buildings\n    \n\n### ❌ No Buildings Exist\n\n- **Then:** Returns empty array\n    \n\n``` json\n\"buildings\": []\n\n ```\n\n### 🚫 Unauthorized\n\n- **Then:** Returns 401\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with code `4500`\n    \n\n---\n\n## 📌 Notes\n\n- Only buildings belonging to the authenticated user's institution are returned\n    \n- Buildings marked as `is_deleted = True` are excluded\n    \n\n---\n\n## 🏷️ Tags\n\n`#Buildings` `#List` `#GET`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/buildings/`\n    \n- **View:** `list_buildings_view`\n    \n- **Service:** `list_buildings()`\n    \n- **Repository:** `list_buildings_by_institution()`\n    \n- **Serializer:** `BuildingSerializer`\n    \n- **Model:** `Building`\n    \n\n---\n\nEndFragment"
-							},
-							"response": []
-						},
-						{
-							"name": "Retrieve Building",
-							"request": {
-								"method": "GET",
-								"header": [],
-								"url": {
-									"raw": "{{base_url}}/api/locations/buildings/9/",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"api",
-										"locations",
-										"buildings",
-										"9",
-										""
-									]
-								},
-								"description": "StartFragment\n\n# 📄 `GET - Retrieve Building`\n\n**Folder:** `Buildings/`  \n**Request Name:** `GET - Retrieve Building`\n\n---\n\n## ✅ Description\n\nRetrieves details of a specific building by its ID, only if the building belongs to the authenticated user's institution.\n\n---\n\n## 🔗 Endpoint\n\n```\nGET {{base_url}}/api/locations/buildings/<building_id>/\n\n ```\n\nReplace with the ID of the target building.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `building_id` | int | ✅ | ID of the building to fetch |\n\n---\n\n## 📥 Request Body\n\n_None_\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2501,\n  \"message\": \"ساختمان با موفقیت دریافت شد.\",\n  \"data\": {\n    \"building\": {\n      \"id\": 5,\n      \"title\": \"دانشکده مهندسی\",\n      \"institution\": 3\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 404 Not Found - Building Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4100,\n  \"message\": \"ساختمان مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 🔒 401 Unauthorized - Invalid Token\n\n``` json\n{\n  \"detail\": \"Invalid token.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4501,\n  \"message\": \"دریافت اطلاعات ساختمان با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token and valid building_id owned by the institution\n    \n- **Then:** Returns 200 with building details\n    \n\n### ❌ Building Not Found\n\n- **When:** building ID does not exist or is not part of the user's institution\n    \n- **Then:** Returns 404 with `code: 4100`\n    \n\n### 🚫 Unauthorized\n\n- **Then:** Returns 401\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with `code: 4501`\n    \n\n---\n\n## 📌 Notes\n\n- Only buildings under the current user's institution can be retrieved\n    \n- `is_deleted = False` is implicitly enforced\n    \n\n---\n\n## 🏷️ Tags\n\n`#Buildings` `#Retrieve` `#GET`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/buildings//`\n    \n- **View:** `retrieve_building_view`\n    \n- **Service:** `get_building_by_id_or_404()`\n    \n- **Repository:** `get_building_by_id_and_institution()`\n    \n- **Serializer:** `BuildingSerializer`\n    \n- **Model:** `Building`\n    \n\n---\n\nEndFragment"
-							},
-							"response": []
-						},
-						{
-							"name": "Create Building",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "formdata",
-									"formdata": [
-										{
-											"key": "title",
-											"value": "ساختمان اموزش2",
-											"type": "text"
-										}
-									]
-								},
-								"url": {
-									"raw": "{{base_url}}/api/locations/buildings/create/",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"api",
-										"locations",
-										"buildings",
-										"create",
-										""
-									]
-								},
-								"description": "StartFragment\n\n# 📄 `POST - Create Building`\n\n**Folder:** `Buildings/`  \n**Request Name:** `POST - Create Building`\n\n---\n\n## ✅ Description\n\nCreates a new building under the authenticated user's institution. Title must be provided and will be associated with the user's institution.\n\n---\n\n## 🔗 Endpoint\n\n```\nPOST {{base_url}}/api/locations/buildings/create/\n\n ```\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 📥 Request Body (JSON)\n\n| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n| title | string | ✅ | Name of the building |\n\n### 🔸 Example:\n\n``` json\n{\n  \"title\": \"ساختمان آزمایشگاه مرکزی\"\n}\n\n ```\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `201 Created`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2502,\n  \"message\": \"ساختمان جدید با موفقیت ایجاد شد.\",\n  \"data\": {\n    \"building\": {\n      \"id\": 7,\n      \"title\": \"ساختمان آزمایشگاه مرکزی\",\n      \"institution\": 3\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 400 Validation Error - Missing/Invalid Title\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4102,\n  \"message\": \"اعتبارسنجی انجام نشد.\",\n  \"errors\": {\n    \"title\": [\"This field is required.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing/Invalid Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4502,\n  \"message\": \"ایجاد ساختمان با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Title provided and token is valid\n    \n- **Then:** Returns 201 with building data\n    \n\n### ❌ Missing Title\n\n- **Then:** Returns 400 with validation error\n    \n\n### 🚫 Unauthorized\n\n- **Then:** Returns 401\n    \n\n### 💥 Server Failure\n\n- **Then:** Returns 500 with `code: 4502`\n    \n\n---\n\n## 📌 Notes\n\n- The `institution` is automatically inferred from the authenticated user\n    \n- Title does not need to be unique globally, only meaningful per institution\n    \n\n---\n\n## 🏷️ Tags\n\n`#Buildings` `#Create` `#POST`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/buildings/create/`\n    \n- **View:** `create_building_view`\n    \n- **Service:** `create_building()`\n    \n- **Repository:** `create_building()`\n    \n- **Serializer:** `CreateBuildingSerializer`\n    \n- **Model:** `Building`\n    \n\n---\n\nEndFragment"
-							},
-							"response": []
-						},
-						{
-							"name": "Update Building",
-							"request": {
-								"method": "PUT",
-								"header": [],
-								"body": {
-									"mode": "formdata",
-									"formdata": [
-										{
-											"key": "title",
-											"value": "ساختمان جدید علوم پایه",
-											"type": "text"
-										}
-									]
-								},
-								"url": {
-									"raw": "{{base_url}}/api/locations/buildings/9/update/",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"api",
-										"locations",
-										"buildings",
-										"9",
-										"update",
-										""
-									]
-								},
-								"description": "StartFragment\n\n# 📄 `PUT - Update Building`\n\n**Folder:** `Buildings/`  \n**Request Name:** `PUT - Update Building`\n\n---\n\n## ✅ Description\n\nUpdates the title of a building that belongs to the authenticated user's institution. Only the `title` field is updatable.\n\n---\n\n## 🔗 Endpoint\n\n```\nPUT {{base_url}}/api/locations/buildings/<building_id>/update/\n\n ```\n\nReplace with the ID of the target building.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `building_id` | int | ✅ | ID of the building to update |\n\n---\n\n## 📥 Request Body (JSON)\n\n| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n| title | string | ❌ | New title for the building |\n\n### 🔸 Example:\n\n``` json\n{\n  \"title\": \"ساختمان پژوهشی ۲\"\n}\n\n ```\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2503,\n  \"message\": \"ساختمان با موفقیت به‌روزرسانی شد.\",\n  \"data\": {\n    \"building\": {\n      \"id\": 5,\n      \"title\": \"ساختمان پژوهشی ۲\",\n      \"institution\": 3\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 404 Not Found - Building Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4100,\n  \"message\": \"ساختمان مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### ❌ 400 Validation Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4102,\n  \"message\": \"اعتبارسنجی انجام نشد.\",\n  \"errors\": {\n    \"title\": [\"Ensure this field has no more than 255 characters.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing/Invalid Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4503,\n  \"message\": \"به‌روزرسانی ساختمان با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token and building ID + valid `title`\n    \n- **Then:** Returns 200 with updated building\n    \n\n### ❌ Building Not Found\n\n- **Then:** Returns 404 with code `4100`\n    \n\n### ❌ Validation Error\n\n- **When:** `title` too long or invalid\n    \n- **Then:** Returns 400\n    \n\n### 🚫 Unauthorized\n\n- **Then:** Returns 401\n    \n\n### 💥 Server Error\n\n- **Then:** Returns 500 with code `4503`\n    \n\n---\n\n## 📌 Notes\n\n- Only `title` can be updated\n    \n- Building must belong to the authenticated user's institution\n    \n\n---\n\n## 🏷️ Tags\n\n`#Buildings` `#Update` `#PUT`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/buildings//update/`\n    \n- **View:** `update_building_view`\n    \n- **Service:** `update_building()`\n    \n- **Repository:** `update_building_fields()`\n    \n- **Serializer:** `UpdateBuildingSerializer`\n    \n- **Model:** `Building`\n    \n\n---\n\nEndFragment"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete Building",
-							"request": {
-								"method": "DELETE",
-								"header": [],
-								"url": {
-									"raw": "{{base_url}}/api/locations/buildings/12/delete/",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"api",
-										"locations",
-										"buildings",
-										"12",
-										"delete",
-										""
-									]
-								},
-								"description": "StartFragment\n\n# 📄 `DELETE - Delete Building`\n\n**Folder:** `Buildings/`  \n**Request Name:** `DELETE - Delete Building`\n\n---\n\n## ✅ Description\n\nSoft deletes a building by its ID. The building must belong to the authenticated user's institution.\n\n---\n\n## 🔗 Endpoint\n\n```\nDELETE {{base_url}}/api/locations/buildings/<building_id>/delete/\n\n ```\n\nReplace with the numeric ID of the target building.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `building_id` | int | ✅ | ID of the building to delete |\n\n---\n\n## 📥 Request Body\n\n_None_\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2504,\n  \"message\": \"ساختمان با موفقیت حذف شد.\",\n  \"data\": {},\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 404 Not Found - Building Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4100,\n  \"message\": \"ساختمان مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4504,\n  \"message\": \"حذف ساختمان با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token and building ID exists\n    \n- **Then:** Returns 200 with confirmation message\n    \n\n### ❌ Building Not Found\n\n- **Then:** Returns 404\n    \n\n### 🚫 Unauthorized\n\n- **Then:** Returns 401\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with `code: 4504`\n    \n\n---\n\n## 📌 Notes\n\n- Only buildings belonging to the current user's institution can be deleted\n    \n- The deletion is soft (sets `is_deleted = True`)\n    \n\n---\n\n## 🏷️ Tags\n\n`#Buildings` `#Delete` `#DELETE`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/buildings//delete/`\n    \n- **View:** `delete_building_view`\n    \n- **Service:** `delete_building()`\n    \n- **Repository:** `soft_delete_building()`\n    \n- **Model:** `Building`\n    \n\n---\n\nEndFragment"
-							},
-							"response": []
-						}
-					]
-				},
-				{
-					"name": "Classrooms",
-					"item": [
-						{
-							"name": "List All Classrooms",
-							"request": {
-								"method": "GET",
-								"header": [],
-								"url": {
-									"raw": "{{base_url}}/api/locations/classrooms/all/",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"api",
-										"locations",
-										"classrooms",
-										"all",
-										""
-									]
-								},
-								"description": "StartFragment\n\n# 📄 `GET - List All Classrooms`\n\n**Folder:** `Classrooms/`  \n**Request Name:** `GET - List All Classrooms`\n\n---\n\n## ✅ Description\n\nReturns all active classrooms (`is_deleted = False`) across all buildings of the authenticated user's institution.\n\n---\n\n## 🔗 Endpoint\n\n```\nGET {{base_url}}/api/locations/classrooms/all/\n\n ```\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 📥 Request Body\n\n_None_\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2505,\n  \"message\": \"لیست کلاس‌ها با موفقیت دریافت شد.\",\n  \"data\": {\n    \"classrooms\": [\n      {\n        \"id\": 1,\n        \"title\": \"کلاس ۱۰۱\",\n        \"building\": 3\n      },\n      {\n        \"id\": 2,\n        \"title\": \"آزمایشگاه شبکه\",\n        \"building\": 4\n      }\n    ]\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### 🔒 401 Unauthorized - Missing Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 🔒 401 Unauthorized - Invalid Token\n\n``` json\n{\n  \"detail\": \"Invalid token.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4505,\n  \"message\": \"دریافت لیست کلاس‌ها با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token, classrooms exist in the institution\n    \n- **Then:** Returns 200 with classroom list\n    \n\n### ❌ No Classrooms Exist\n\n- **Then:** Returns:\n    \n\n``` json\n\"classrooms\": []\n\n ```\n\n### 🚫 Unauthorized - Missing or Invalid Token\n\n- **Then:** Returns 401\n    \n\n### ⛔ Forbidden\n\n- **Then:** Returns 403\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with code `4505`\n    \n\n---\n\n## 📌 Notes\n\n- All classrooms belong to buildings in the authenticated user's institution\n    \n- Only classrooms with `is_deleted = False` are returned\n    \n\n---\n\n## 🏷️ Tags\n\n`#Classrooms` `#List` `#Institution` `#GET`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/classrooms/all/`\n    \n- **View:** `list_all_classrooms_view`\n    \n- **Service:** `list_classrooms_for_institution()`\n    \n- **Repository:** `list_classrooms_by_institution()`\n    \n- **Serializer:** `ClassroomSerializer`\n    \n- **Model:** `Classroom`\n    \n\n---\n\nEndFragment"
-							},
-							"response": []
-						},
-						{
-							"name": "List Classrooms by Building",
-							"request": {
-								"method": "GET",
-								"header": [],
-								"url": {
-									"raw": "{{base_url}}/api/locations/buildings/9/classrooms/",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"api",
-										"locations",
-										"buildings",
-										"9",
-										"classrooms",
-										""
-									]
-								},
-								"description": "StartFragment\n\n# 📄 `GET - List Classrooms by Building`\n\n**Folder:** `Classrooms/`  \n**Request Name:** `GET - List Classrooms by Building`\n\n---\n\n## ✅ Description\n\nReturns all active classrooms (`is_deleted = False`) under a specific building for the authenticated user's institution.\n\n---\n\n## 🔗 Endpoint\n\n```\nGET {{base_url}}/api/locations/buildings/<building_id>/classrooms/\n\n ```\n\nReplace with the numeric ID of the target building.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `building_id` | int | ✅ | ID of the target building |\n\n---\n\n## 📥 Request Body\n\n_None_\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2505,\n  \"message\": \"لیست کلاس‌ها با موفقیت دریافت شد.\",\n  \"data\": {\n    \"classrooms\": [\n      {\n        \"id\": 1,\n        \"title\": \"کلاس ۱۰۱\",\n        \"building\": 3\n      },\n      {\n        \"id\": 2,\n        \"title\": \"آزمایشگاه شبکه\",\n        \"building\": 3\n      }\n    ]\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 404 Not Found - Building Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4100,\n  \"message\": \"ساختمان مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 🔒 401 Unauthorized - Invalid Token\n\n``` json\n{\n  \"detail\": \"Invalid token.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4505,\n  \"message\": \"دریافت لیست کلاس‌ها با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token, classrooms exist under the specified building\n    \n- **Then:** Returns 200 with classrooms list\n    \n\n### ❌ No Classrooms Exist\n\n- **Then:** Returns:\n    \n\n``` json\n\"classrooms\": []\n\n ```\n\n### ❌ Building Not Found\n\n- **Then:** Returns 404 with code `4100`\n    \n\n### 🚫 Unauthorized - Missing Token\n\n- **Then:** Returns 401\n    \n\n### 🚫 Unauthorized - Invalid Token\n\n- **Then:** Returns 401\n    \n\n### ⛔ Forbidden\n\n- **Then:** Returns 403\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with code `4505`\n    \n\n---\n\n## 📌 Notes\n\n- All classrooms belong to the provided building ID and the authenticated user's institution\n    \n- Only classrooms with `is_deleted = False` are returned\n    \n\n---\n\n## 🏷️ Tags\n\n`#Classrooms` `#List` `#ByBuilding` `#GET`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/buildings//classrooms/`\n    \n- **View:** `list_classrooms_view`\n    \n- **Service:** `list_classrooms()`\n    \n- **Repository:** `list_classrooms_by_building()`\n    \n- **Serializer:** `ClassroomSerializer`\n    \n- **Model:** `Classroom`\n    \n\n---\n\nEndFragment"
-							},
-							"response": []
-						},
-						{
-							"name": "Retrieve Classroom",
-							"request": {
-								"method": "GET",
-								"header": [],
-								"url": {
-									"raw": "{{base_url}}/api/locations/classrooms/1/",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"api",
-										"locations",
-										"classrooms",
-										"1",
-										""
-									]
-								},
-								"description": "StartFragment\n\n# 📄 `GET - Retrieve Classroom`\n\n**Folder:** `Classrooms/`  \n**Request Name:** `GET - Retrieve Classroom`\n\n---\n\n## ✅ Description\n\nRetrieves a specific classroom by its ID, **if it belongs to the authenticated user's institution**.\n\n---\n\n## 🔗 Endpoint\n\n```\nGET {{base_url}}/api/locations/classrooms/<classroom_id>/\n\n ```\n\nReplace with the numeric ID of the classroom to retrieve.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `classroom_id` | int | ✅ | ID of the classroom to retrieve |\n\n---\n\n## 📥 Request Body\n\n_None_\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2506,\n  \"message\": \"کلاس با موفقیت بازیابی شد.\",\n  \"data\": {\n    \"classroom\": {\n      \"id\": 4,\n      \"title\": \"کلاس ۱۰۱\",\n      \"building\": 2\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 404 Not Found - Classroom Not Found or Not Belonging to Institution\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4600,\n  \"message\": \"کلاس مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 🔒 401 Unauthorized - Invalid Token\n\n``` json\n{\n  \"detail\": \"Invalid token.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4601,\n  \"message\": \"بازیابی کلاس با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token and classroom exists in user's institution\n    \n- **Then:** Returns classroom object with 200\n    \n\n### ❌ Classroom Does Not Exist\n\n- **Then:** Returns 404 with code `4600`\n    \n\n### ❌ Classroom Not in User's Institution\n\n- **Then:** Returns 404 with code `4600`\n    \n\n### 🚫 Unauthorized - Missing or Invalid Token\n\n- **Then:** Returns 401\n    \n\n### ⛔ Forbidden\n\n- **Then:** Returns 403\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with code `4601`\n    \n\n---\n\n## 📌 Notes\n\n- Classroom must belong to one of the buildings of the authenticated user's institution\n    \n- Classroom must not be soft-deleted (`is_deleted = False`)\n    \n\n---\n\n## 🏷️ Tags\n\n`#Classrooms` `#Retrieve` `#GET`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/classrooms//`\n    \n- **View:** `retrieve_classroom_view`\n    \n- **Service:** `get_classroom_by_id_and_institution_or_404()`\n    \n- **Repository:** `get_classroom_by_id_and_institution()`\n    \n- **Serializer:** `ClassroomSerializer`\n    \n- **Model:** `Classroom`\n    \n\n---\n\nEndFragment"
-							},
-							"response": []
-						},
-						{
-							"name": "Create Classroom",
-							"request": {
-								"method": "POST",
-								"header": [],
-								"body": {
-									"mode": "formdata",
-									"formdata": [
-										{
-											"key": "title",
-											"value": "آزمایشگاه شبکه",
-											"type": "text"
-										}
-									]
-								},
-								"url": {
-									"raw": "{{base_url}}/api/locations/buildings/9/classrooms/create/",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"api",
-										"locations",
-										"buildings",
-										"9",
-										"classrooms",
-										"create",
-										""
-									]
-								},
-								"description": "StartFragment\n\n# 📄 `POST - Create Classroom`\n\n**Folder:** `Classrooms/`  \n**Request Name:** `POST - Create Classroom`\n\n---\n\n## ✅ Description\n\nCreates a new classroom under a specific building belonging to the authenticated user's institution.\n\n---\n\n## 🔗 Endpoint\n\n```\nPOST {{base_url}}/api/locations/buildings/<building_id>/classrooms/create/\n\n ```\n\nReplace with the numeric ID of the target building.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `building_id` | int | ✅ | ID of the target building |\n\n---\n\n## 📥 Request Body\n\n**Content-Type:** `application/json`\n\n``` json\n{\n  \"title\": \"آزمایشگاه شبکه\"\n}\n\n ```\n\n| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n| title | string | ✅ | Name of the classroom to be added |\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `201 Created`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2504,\n  \"message\": \"کلاس با موفقیت ایجاد شد.\",\n  \"data\": {\n    \"classroom\": {\n      \"id\": 12,\n      \"title\": \"آزمایشگاه شبکه\",\n      \"building\": 3\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 400 Bad Request - Validation Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4102,\n  \"message\": \"خطا در اعتبارسنجی داده‌ها.\",\n  \"errors\": {\n    \"title\": [\"این فیلد نمی‌تواند خالی باشد.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n### ❌ 404 Not Found - Building Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4100,\n  \"message\": \"ساختمان مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 🔒 401 Unauthorized - Invalid Token\n\n``` json\n{\n  \"detail\": \"Invalid token.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4602,\n  \"message\": \"ایجاد کلاس با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token, valid building_id, valid data\n    \n- **Then:** Returns `201` with created classroom\n    \n\n### ❌ Validation Error\n\n- **When:** `title` is missing or blank\n    \n- **Then:** Returns 400 with code `4102`\n    \n\n### ❌ Building Not Found\n\n- **When:** building ID is invalid or not owned by user's institution\n    \n- **Then:** Returns 404 with code `4100`\n    \n\n### 🚫 Unauthorized - Missing/Invalid Token\n\n- **Then:** Returns 401\n    \n\n### ⛔ Forbidden\n\n- **Then:** Returns 403\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with code `4602`\n    \n\n---\n\n## 📌 Notes\n\n- Classroom is always tied to a building, and building must belong to the authenticated user's institution\n    \n\n---\n\n## 🏷️ Tags\n\n`#Classrooms` `#Create` `#POST`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/buildings//classrooms/create/`\n    \n- **View:** `create_classroom_view`\n    \n- **Service:** `create_classroom()`\n    \n- **Repository:** `create_classroom()`\n    \n- **Serializer:** `CreateClassroomSerializer`\n    \n- **Model:** `Classroom`\n    \n\n---\n\nEndFragment"
-							},
-							"response": []
-						},
-						{
-							"name": "Update Classroom",
-							"request": {
-								"method": "PUT",
-								"header": [],
-								"body": {
-									"mode": "formdata",
-									"formdata": [
-										{
-											"key": "title",
-											"value": "کلاس جدید",
-											"type": "text"
-										}
-									]
-								},
-								"url": {
-									"raw": "{{base_url}}/api/locations/classrooms/2/update/",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"api",
-										"locations",
-										"classrooms",
-										"2",
-										"update",
-										""
-									]
-								},
-								"description": "StartFragment\n\n# 📄 `PUT - Update Classroom`\n\n**Folder:** `Classrooms/`  \n**Request Name:** `PUT - Update Classroom`\n\n---\n\n## ✅ Description\n\nUpdates the title of a specific classroom using its ID, **if it belongs to the authenticated user's institution**.\n\n---\n\n## 🔗 Endpoint\n\n```\nPUT {{base_url}}/api/locations/classrooms/<classroom_id>/update/\n\n ```\n\nReplace with the ID of the classroom to update.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `classroom_id` | int | ✅ | ID of the classroom to update |\n\n---\n\n## 📥 Request Body\n\n**Content-Type:** `application/json`\n\n``` json\n{\n  \"title\": \"کلاس جدید\"\n}\n\n ```\n\n| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n| title | string | ❌ | New title for the classroom |\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2507,\n  \"message\": \"کلاس با موفقیت به‌روزرسانی شد.\",\n  \"data\": {\n    \"classroom\": {\n      \"id\": 4,\n      \"title\": \"کلاس جدید\",\n      \"building\": 2\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 400 Bad Request - Validation Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4102,\n  \"message\": \"خطا در اعتبارسنجی داده‌ها.\",\n  \"errors\": {\n    \"title\": [\"این فیلد نمی‌تواند خالی باشد.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n### ❌ 404 Not Found - Classroom Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4600,\n  \"message\": \"کلاس مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing/Invalid Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4603,\n  \"message\": \"ویرایش کلاس با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid `classroom_id` and valid token and data\n    \n- **Then:** Returns 200 with updated classroom info\n    \n\n### ❌ Validation Error\n\n- **When:** title is invalid (e.g. blank or too long)\n    \n- **Then:** Returns 400 with `code: 4102`\n    \n\n### ❌ Classroom Not Found\n\n- **When:** classroom doesn’t exist or not under user's institution\n    \n- **Then:** Returns 404 with `code: 4600`\n    \n\n### 🚫 Unauthorized\n\n- **Then:** Returns 401\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with `code: 4603`\n    \n\n---\n\n## 📌 Notes\n\n- `building_id` is no longer required; classroom is resolved via institution linkage\n    \n- Partial updates are supported; only `title` can be updated\n    \n\n---\n\n## 🏷️ Tags\n\n`#Classrooms` `#Update` `#PUT`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/classrooms//update/`\n    \n- **View:** `update_classroom_view`\n    \n- **Service:** `update_classroom()`\n    \n- **Repository:** `get_classroom_by_id_and_institution()`\n    \n- **Serializer:** `UpdateClassroomSerializer`\n    \n- **Model:** `Classroom`\n    \n\n---\n\nEndFragment"
-							},
-							"response": []
-						},
-						{
-							"name": "Delete Classroom",
-							"request": {
-								"method": "DELETE",
-								"header": [],
-								"url": {
-									"raw": "{{base_url}}/api/locations/classrooms/2/delete/",
-									"host": [
-										"{{base_url}}"
-									],
-									"path": [
-										"api",
-										"locations",
-										"classrooms",
-										"2",
-										"delete",
-										""
-									]
-								},
-								"description": "StartFragment\n\n# 📄 `DELETE - Delete Classroom`\n\n**Folder:** `Classrooms/`  \n**Request Name:** `DELETE - Delete Classroom`\n\n---\n\n## ✅ Description\n\nSoft-deletes a classroom (sets `is_deleted = true`) if it belongs to the authenticated user's institution.\n\n---\n\n## 🔗 Endpoint\n\n```\nDELETE {{base_url}}/api/locations/classrooms/<classroom_id>/delete/\n\n ```\n\nReplace with the ID of the classroom to delete.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `classroom_id` | int | ✅ | ID of the classroom to delete |\n\n---\n\n## 📥 Request Body\n\n_None_\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2508,\n  \"message\": \"کلاس با موفقیت حذف شد.\",\n  \"data\": {},\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 404 Not Found - Classroom Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4600,\n  \"message\": \"کلاس مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing/Invalid Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4604,\n  \"message\": \"حذف کلاس با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid classroom ID owned by the user's institution\n    \n- **Then:** Returns 200 with confirmation message\n    \n\n### ❌ Classroom Not Found\n\n- **When:** Invalid or unauthorized classroom ID\n    \n- **Then:** Returns 404 with `code: 4600`\n    \n\n### 🚫 Unauthorized\n\n- **Then:** Returns 401\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with `code: 4604`\n    \n\n---\n\n## 📌 Notes\n\n- This is a _soft delete_ operation — classroom remains in DB but flagged as deleted\n    \n- Operation is only allowed if the classroom belongs to the current user's institution\n    \n- `building_id` is not required anymore for deletion\n    \n\n---\n\n## 🏷️ Tags\n\n`#Classrooms` `#Delete` `#SoftDelete` `#DELETE`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/classrooms//delete/`\n    \n- **View:** `delete_classroom_view`\n    \n- **Service:** `delete_classroom()` + `get_classroom_instance_by_institution_or_404()`\n    \n- **Repository:** `soft_delete_classroom()`\n    \n- **Model:** `Classroom`\n    \n\n---\n\nEndFragment"
-							},
-							"response": []
-						}
-					]
-				}
-			]
-		}
-	],
-	"auth": {
-		"type": "apikey",
-		"apikey": [
-			{
-				"key": "value",
-				"value": "Token {{token}}",
-				"type": "string"
-			},
-			{
-				"key": "key",
-				"value": "Authorization",
-				"type": "string"
-			}
-		]
-	},
-	"event": [
-		{
-			"listen": "prerequest",
-			"script": {
-				"type": "text/javascript",
-				"packages": {},
-				"exec": [
-					""
-				]
-			}
-		},
-		{
-			"listen": "test",
-			"script": {
-				"type": "text/javascript",
-				"packages": {},
-				"exec": [
-					""
-				]
-			}
-		}
-	]
+                                                "description": "StartFragment\n\n### 🟡 PUT - Update Professor\n\n**Endpoint:**\n\n```\nPUT api/professors/:id/update/\n\n ```\n\n**Description:**\n\nUpdate an existing professor's profile (first name, last name, or phone number) in the authenticated user's institution.\n\n---\n\n### 🔐 Authorization\n\n- Required: ✅ Yes\n    \n- Type: Bearer Token (use `{{token}}` in environment)\n    \n\n---\n\n### 📥 Request Parameters\n\n#### 🔹 Path Parameters:\n\n| Param | Type | Required | Description |\n| --- | --- | --- | --- |\n| id | int | ✅ | ID of the professor to update |\n\n#### 🔸 Body (JSON):\n\n``` json\n{\n  \"first_name\": \"Ali\",\n  \"last_name\": \"Ahmadi\",\n  \"phone_number\": \"09123456789\"\n}\n\n ```\n\n- All fields are optional (partial update supported)\n    \n- If field is not included, it will remain unchanged.\n    \n\n---\n\n### 📤 Success Response (200 OK)\n\n``` json\n{\n  \"status\": true,\n  \"code\": \"PROFESSOR_UPDATED\",\n  \"message\": \"Professor updated successfully.\",\n  \"data\": {\n    \"professor\": {\n      \"id\": 5,\n      \"first_name\": \"Ali\",\n      \"last_name\": \"Ahmadi\",\n      \"national_code\": \"0076543210\",\n      \"phone_number\": \"09123456789\",\n      \"institution\": 1\n    }\n  }\n}\n\n ```\n\n---\n\n### ❌ Error Responses\n\n#### 🔸 404 - Professor Not Found\n\n``` json\n{\n  \"status\": false,\n  \"code\": \"PROFESSOR_NOT_FOUND\",\n  \"message\": \"Professor not found.\",\n  \"errors\": {},\n  \"data\": null\n}\n\n ```\n\n#### 🔸 400 - Validation Error\n\n``` json\n{\n  \"status\": false,\n  \"code\": \"VALIDATION_FAILED\",\n  \"message\": \"Validation failed.\",\n  \"errors\": {\n    \"phone_number\": [\"Enter a valid phone number.\"]\n  },\n  \"data\": null\n}\n\n ```\n\n#### 🔸 500 - Update Failed\n\n``` json\n{\n  \"status\": false,\n  \"code\": \"PROFESSOR_UPDATE_FAILED\",\n  \"message\": \"Could not update professor.\",\n  \"errors\": {},\n  \"data\": null\n}\n\n ```\n\n---\n\n### 🧠 Notes\n\n- Fields are partially updatable (no need to send all fields).\n    \n- If professor with given ID doesn't exist or doesn't belong to the user's institution, 404 will be returned.\n    \n- All validation errors return `4102` project-specific code (`VALIDATION_FAILED`).\n    \n- Uses standard `BaseResponse` structure.\n    \n\n---\n\n### 📁 Folder in Postman\n\n```\nProfessors/\n  └── PUT - Update\n\n ```\n\n### 🔧 Environment Variables Required\n\n- `{{base_url}}`\n    \n- `{{token}}`\n    \n\nEndFragment"
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "Delete Professor",
+                                        "request": {
+                                                "method": "DELETE",
+                                                "header": [],
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/professors/1/delete/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "professors",
+                                                                "1",
+                                                                "delete"
+                                                        ]
+                                                },
+                                                "description": "StartFragment\n\n### ❌ **DELETE - Delete Professor**\n\n**Description**\n\nSoft deletes a professor by ID from the authenticated user's institution. The professor will remain in the database but marked as deleted.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nDELETE {{base_url}}/api/professors/<professor_id>/delete/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Path Parameters**\n\n| Parameter | Type | Required | Description |\n| --- | --- | --- | --- |\n| `professor_id` | int | ✅ | ID of the professor to be deleted |\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n  \"success\": true,\n  \"code\": \"2203\",\n  \"message\": \"استاد با موفقیت حذف شد.\",\n  \"data\": {},\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4100` | ترم مورد نظر یافت نشد. | 404 Not Found | If the professor with the given ID does not exist or does not belong to the institution |\n| `4203` | حذف استاد با خطا مواجه شد. | 500 Internal Error | Unexpected server-side error during deletion |\n| `401` | Authentication credentials were not provided. | 401 Unauthorized | Token missing or invalid |\n\n#### 🔻 Example: Professor Not Found\n\n``` json\n{\n  \"success\": false,\n  \"message\": \"استاد مورد نظر یافت نشد.\",\n  \"code\": \"4100\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n#### 🔻 Example: Server Error\n\n``` json\n{\n  \"success\": false,\n  \"message\": \"حذف استاد با خطا مواجه شد.\",\n  \"code\": \"4203\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid ID** → Professor is soft deleted → `200 OK`\n    \n- ❌ **Invalid or non-existent ID** → `4100`\n    \n- ❌ **No token provided** → `401 Unauthorized`\n    \n- ❌ **Server crash** → `4203`\n    \n\nEndFragment"
+                                        },
+                                        "response": []
+                                }
+                        ]
+                },
+                {
+                        "name": "Courses",
+                        "item": [
+                                {
+                                        "name": "List Courses",
+                                        "request": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/courses/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "courses"
+                                                        ]
+                                                },
+                                                "description": "StartFragment\n\n### 📄 **GET - List Courses**\n\n**Description**\n\nدریافت لیست تمام درس‌هایی که متعلق به موسسه کاربر احراز هویت شده هستند.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nGET {{base_url}}/api/courses/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n  \"success\": true,\n  \"code\": \"2301\",\n  \"message\": \"لیست درس‌ها با موفقیت دریافت شد.\",\n  \"data\": {\n    \"courses\": [\n      {\n        \"id\": 1,\n        \"code\": \"ISLAM101\",\n        \"title\": \"اندیشه اسلامی 1\",\n        \"professor\": 3,\n        \"offer_code\": \"1404-1-IS101-A\",\n        \"unit_count\": 3,\n        \"is_active\": true\n      }\n    ]\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `401` | Authentication credentials were not provided. | 401 Unauthorized | توکن ارائه نشده یا معتبر نیست |\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **کاربر احراز شده** → لیست دروس را دریافت می‌کند → `200 OK`\n- ❌ **کاربر بدون توکن** → `401 Unauthorized`\n    \n\nEndFragment"
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "Retrieve Course",
+                                        "request": {
+                                                "method": "GET",
+                                                "header": [],
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/courses/1/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "courses",
+                                                                "1"
+                                                        ]
+                                                },
+                                                "description": "StartFragment\n\n### 🔍 **GET - Retrieve Course**\n\n**Description**\n\nRetrieves a single course by ID for the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nGET {{base_url}}/api/courses/<course_id>/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n  \"success\": true,\n  \"code\": \"2302\",\n  \"message\": \"Course retrieved successfully.\",\n  \"data\": {\n    \"course\": {\n      \"id\": 2,\n      \"title\": \"تفکر اسلامی\",\n      \"code\": \"ISLAM101\",\n      \"offer_code\": \"1404-1-IS101-B\",\n      \"unit_count\": 3,\n      \"is_active\": true,\n      \"professor\": 7,\n      \"institution\": 1\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4300` | درس مورد نظر یافت نشد. | 404 Not Found | Course not found or does not belong to user |\n| `401` | Authentication credentials were not provided. | 401 Unauthorized | Token missing or invalid |\n\n#### 🔻 Example: Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": \"4300\",\n  \"message\": \"درس مورد نظر یافت نشد.\",\n  \"data\": {},\n  \"errors\": []\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid course ID** → Course returned successfully → `200 OK`\n    \n- ❌ **Invalid or inaccessible course ID** → `4300` → Not Found\n    \n- ❌ **Missing token** → `401` → Unauthorized\n    \n\nEndFragment"
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "Create Course",
+                                        "request": {
+                                                "method": "POST",
+                                                "header": [],
+                                                "body": {
+                                                        "mode": "formdata",
+                                                        "formdata": [
+                                                                {
+                                                                        "key": "title",
+                                                                        "value": "زبان",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "code",
+                                                                        "value": "1010",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "offer_code",
+                                                                        "value": "1012",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "unit_count",
+                                                                        "value": "3",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "is_active",
+                                                                        "value": "True",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "professor",
+                                                                        "value": "2",
+                                                                        "type": "text"
+                                                                }
+                                                        ]
+                                                },
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/courses/create/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "courses",
+                                                                "create"
+                                                        ]
+                                                }
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "Update Course",
+                                        "request": {
+                                                "method": "PUT",
+                                                "header": [],
+                                                "body": {
+                                                        "mode": "formdata",
+                                                        "formdata": [
+                                                                {
+                                                                        "key": "title",
+                                                                        "value": "انگلیسی",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "unit_count",
+                                                                        "value": "",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "is_active",
+                                                                        "value": "",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "professor",
+                                                                        "value": "",
+                                                                        "type": "text"
+                                                                }
+                                                        ]
+                                                },
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/courses/2/update/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "courses",
+                                                                "2",
+                                                                "update"
+                                                        ]
+                                                },
+                                                "description": "StartFragment\n\n### 🆕 **PUT - Update Course**\n\n**Description**  \n  \nUpdates an existing course under the authenticated user's institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nPUT {{base_url}}/api/courses/<course_id>/update/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Body (JSON)**\n\n``` json\n{\n  \"title\": \"اندیشه اسلامی ۱ - ویرایش شده\",\n  \"unit_count\": 2,\n  \"is_active\": false,\n  \"professor\": 4\n}\n\n ```\n\n| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n| `title` | string | ❌ | New title for the course |\n| `unit_count` | int | ❌ | Updated unit count (defaults to 3) |\n| `is_active` | bool | ❌ | Whether course is currently active |\n| `professor` | int | ❌ | ID of the updated professor (if changed) |\n\nNote: Fields are optional; only provided fields will be updated.\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n  \"success\": true,\n  \"code\": \"2302\",\n  \"message\": \"اطلاعات درس با موفقیت به‌روزرسانی شد.\",\n  \"data\": {\n    \"course\": {\n      \"id\": 9,\n      \"title\": \"اندیشه اسلامی ۱ - ویرایش شده\",\n      \"code\": \"ISLAM101\",\n      \"offer_code\": \"1404-1-IS101-X\",\n      \"unit_count\": 2,\n      \"is_active\": false,\n      \"professor\": 4,\n      \"institution\": 1\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4102` | اطلاعات وارد شده نامعتبر است. | 400 Bad Request | Validation failed |\n| `4302` | به‌روزرسانی اطلاعات درس با خطا مواجه شد. | 500 Internal Error | Server-side error during update |\n| `4100` | درس مورد نظر یافت نشد. | 404 Not Found | Invalid `course_id` or unauthorized access |\n| `401` | Authentication credentials were not provided. | 401 Unauthorized | Missing/invalid token |\n\n#### 🔻 Example: Validation Error (Invalid unit count)\n\n``` json\n{\n  \"success\": false,\n  \"code\": \"4102\",\n  \"message\": \"اطلاعات وارد شده نامعتبر است.\",\n  \"errors\": {\n    \"unit_count\": [\"Ensure this value is greater than or equal to 1.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n#### 🔻 Example: Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": \"4100\",\n  \"message\": \"درس مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n#### 🔻 Example: Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": \"4302\",\n  \"message\": \"به‌روزرسانی اطلاعات درس با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Partial update (only title)** → `200 OK`\n    \n- ❌ **Invalid field value (e.g. unit_count < 1)** → `4102`\n    \n- ❌ **Unauthorized access** → `401`\n    \n- ❌ **Course not found** → `4100`\n    \n- ❌ **Unhandled server error** → `4302`\n    \n\nEndFragment"
+                                        },
+                                        "response": []
+                                },
+                                {
+                                        "name": "Delete Course",
+                                        "request": {
+                                                "method": "DELETE",
+                                                "header": [],
+                                                "url": {
+                                                        "raw": "{{base_url}}/api/courses/2/delete/",
+                                                        "host": [
+                                                                "{{base_url}}"
+                                                        ],
+                                                        "path": [
+                                                                "api",
+                                                                "courses",
+                                                                "2",
+                                                                "delete"
+                                                        ]
+                                                },
+                                                "description": "StartFragment\n\n---\n\n### ❌ **DELETE - Delete Course**\n\n**Description**\n\nSoft deletes a course (without permanent removal) by setting `is_deleted=True`. Only accessible to users within the same institution.\n\n---\n\n### 🔗 **Endpoint**\n\n```\nDELETE {{base_url}}/api/courses/<course_id>/delete/\n\n ```\n\n---\n\n### 🔐 **Authentication**\n\nRequired (Token Authentication)\n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n### 📥 **Request Parameters**\n\n| Param | In | Type | Required | Description |\n| --- | --- | --- | --- | --- |\n| `course_id` | path | int | ✅ | ID of the course to be deleted |\n\n---\n\n### 📤 **Success Response (200 OK)**\n\n``` json\n{\n  \"success\": true,\n  \"code\": \"2303\",\n  \"message\": \"درس با موفقیت حذف شد.\",\n  \"data\": {},\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n### ❗ Possible Errors\n\n| Code | Message | HTTP Status | Description |\n| --- | --- | --- | --- |\n| `4100` | درس مورد نظر یافت نشد. | 404 Not Found | Invalid `course_id` or unauthorized access |\n| `4303` | حذف درس با خطا مواجه شد. | 500 Internal Error | Unhandled server error during deletion |\n| `401` | Authentication credentials were not provided. | 401 Unauthorized | Missing or invalid token |\n\n#### 🔻 Example: Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": \"4100\",\n  \"message\": \"درس مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n#### 🔻 Example: Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": \"4303\",\n  \"message\": \"حذف درس با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n### 🧪 **Scenarios**\n\n- ✅ **Valid course ID in user’s institution** → `200 OK`\n    \n- ❌ **Invalid course ID** → `4100`\n    \n- ❌ **Unauthorized request** → `401`\n    \n- ❌ **Server error** → `4303`\n    \n\n---\n\nEndFragment"
+                                        },
+                                        "response": []
+                                }
+                        ]
+                },
+                {
+                        "name": "Locations",
+                        "item": [
+                                {
+                                        "name": "Buildings",
+                                        "item": [
+                                                {
+                                                        "name": "List Buildings",
+                                                        "request": {
+                                                                "method": "GET",
+                                                                "header": [],
+                                                                "url": {
+                                                                        "raw": "{{base_url}}/api/locations/buildings/",
+                                                                        "host": [
+                                                                                "{{base_url}}"
+                                                                        ],
+                                                                        "path": [
+                                                                                "api",
+                                                                                "locations",
+                                                                                "buildings"
+                                                                        ]
+                                                                },
+                                                                "description": "StartFragment\n\n# 📄 `GET - List Buildings`\n\n**Folder:** `Buildings/`  \n**Request Name:** `GET - List Buildings`\n\n---\n\n## ✅ Description\n\nReturns all buildings for the authenticated user's institution. Only buildings that are not soft-deleted (`is_deleted = False`) will be returned.\n\n---\n\n## 🔗 Endpoint\n\n```\nGET {{base_url}}/api/locations/buildings/\n\n ```\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 📥 Request Body\n\n_None_\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2500,\n  \"message\": \"لیست ساختمان‌ها با موفقیت دریافت شد.\",\n  \"data\": {\n    \"buildings\": [\n      {\n        \"id\": 1,\n        \"title\": \"ساختمان شماره یک\",\n        \"institution\": 3\n      },\n      {\n        \"id\": 2,\n        \"title\": \"دانشکده علوم پایه\",\n        \"institution\": 3\n      }\n    ]\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### 🔒 401 Unauthorized - Missing Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 🔒 401 Unauthorized - Invalid Token\n\n``` json\n{\n  \"detail\": \"Invalid token.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4500,\n  \"message\": \"دریافت لیست ساختمان‌ها با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token and buildings exist\n    \n- **Then:** Returns 200 with list of buildings\n    \n\n### ❌ No Buildings Exist\n\n- **Then:** Returns empty array\n    \n\n``` json\n\"buildings\": []\n\n ```\n\n### 🚫 Unauthorized\n\n- **Then:** Returns 401\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with code `4500`\n    \n\n---\n\n## 📌 Notes\n\n- Only buildings belonging to the authenticated user's institution are returned\n    \n- Buildings marked as `is_deleted = True` are excluded\n    \n\n---\n\n## 🏷️ Tags\n\n`#Buildings` `#List` `#GET`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/buildings/`\n    \n- **View:** `list_buildings_view`\n    \n- **Service:** `list_buildings()`\n    \n- **Repository:** `list_buildings_by_institution()`\n    \n- **Serializer:** `BuildingSerializer`\n    \n- **Model:** `Building`\n    \n\n---\n\nEndFragment"
+                                                        },
+                                                        "response": []
+                                                },
+                                                {
+                                                        "name": "Retrieve Building",
+                                                        "request": {
+                                                                "method": "GET",
+                                                                "header": [],
+                                                                "url": {
+                                                                        "raw": "{{base_url}}/api/locations/buildings/9/",
+                                                                        "host": [
+                                                                                "{{base_url}}"
+                                                                        ],
+                                                                        "path": [
+                                                                                "api",
+                                                                                "locations",
+                                                                                "buildings",
+                                                                                "9"
+                                                                        ]
+                                                                },
+                                                                "description": "StartFragment\n\n# 📄 `GET - Retrieve Building`\n\n**Folder:** `Buildings/`  \n**Request Name:** `GET - Retrieve Building`\n\n---\n\n## ✅ Description\n\nRetrieves details of a specific building by its ID, only if the building belongs to the authenticated user's institution.\n\n---\n\n## 🔗 Endpoint\n\n```\nGET {{base_url}}/api/locations/buildings/<building_id>/\n\n ```\n\nReplace with the ID of the target building.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `building_id` | int | ✅ | ID of the building to fetch |\n\n---\n\n## 📥 Request Body\n\n_None_\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2501,\n  \"message\": \"ساختمان با موفقیت دریافت شد.\",\n  \"data\": {\n    \"building\": {\n      \"id\": 5,\n      \"title\": \"دانشکده مهندسی\",\n      \"institution\": 3\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 404 Not Found - Building Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4100,\n  \"message\": \"ساختمان مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 🔒 401 Unauthorized - Invalid Token\n\n``` json\n{\n  \"detail\": \"Invalid token.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4501,\n  \"message\": \"دریافت اطلاعات ساختمان با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token and valid building_id owned by the institution\n    \n- **Then:** Returns 200 with building details\n    \n\n### ❌ Building Not Found\n\n- **When:** building ID does not exist or is not part of the user's institution\n    \n- **Then:** Returns 404 with `code: 4100`\n    \n\n### 🚫 Unauthorized\n\n- **Then:** Returns 401\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with `code: 4501`\n    \n\n---\n\n## 📌 Notes\n\n- Only buildings under the current user's institution can be retrieved\n    \n- `is_deleted = False` is implicitly enforced\n    \n\n---\n\n## 🏷️ Tags\n\n`#Buildings` `#Retrieve` `#GET`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/buildings//`\n    \n- **View:** `retrieve_building_view`\n    \n- **Service:** `get_building_by_id_or_404()`\n    \n- **Repository:** `get_building_by_id_and_institution()`\n    \n- **Serializer:** `BuildingSerializer`\n    \n- **Model:** `Building`\n    \n\n---\n\nEndFragment"
+                                                        },
+                                                        "response": []
+                                                },
+                                                {
+                                                        "name": "Create Building",
+                                                        "request": {
+                                                                "method": "POST",
+                                                                "header": [],
+                                                                "body": {
+                                                                        "mode": "formdata",
+                                                                        "formdata": [
+                                                                                {
+                                                                                        "key": "title",
+                                                                                        "value": "ساختمان اموزش2",
+                                                                                        "type": "text"
+                                                                                }
+                                                                        ]
+                                                                },
+                                                                "url": {
+                                                                        "raw": "{{base_url}}/api/locations/buildings/create/",
+                                                                        "host": [
+                                                                                "{{base_url}}"
+                                                                        ],
+                                                                        "path": [
+                                                                                "api",
+                                                                                "locations",
+                                                                                "buildings",
+                                                                                "create"
+                                                                        ]
+                                                                },
+                                                                "description": "StartFragment\n\n# 📄 `POST - Create Building`\n\n**Folder:** `Buildings/`  \n**Request Name:** `POST - Create Building`\n\n---\n\n## ✅ Description\n\nCreates a new building under the authenticated user's institution. Title must be provided and will be associated with the user's institution.\n\n---\n\n## 🔗 Endpoint\n\n```\nPOST {{base_url}}/api/locations/buildings/create/\n\n ```\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 📥 Request Body (JSON)\n\n| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n| title | string | ✅ | Name of the building |\n\n### 🔸 Example:\n\n``` json\n{\n  \"title\": \"ساختمان آزمایشگاه مرکزی\"\n}\n\n ```\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `201 Created`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2502,\n  \"message\": \"ساختمان جدید با موفقیت ایجاد شد.\",\n  \"data\": {\n    \"building\": {\n      \"id\": 7,\n      \"title\": \"ساختمان آزمایشگاه مرکزی\",\n      \"institution\": 3\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 400 Validation Error - Missing/Invalid Title\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4102,\n  \"message\": \"اعتبارسنجی انجام نشد.\",\n  \"errors\": {\n    \"title\": [\"This field is required.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing/Invalid Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4502,\n  \"message\": \"ایجاد ساختمان با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Title provided and token is valid\n    \n- **Then:** Returns 201 with building data\n    \n\n### ❌ Missing Title\n\n- **Then:** Returns 400 with validation error\n    \n\n### 🚫 Unauthorized\n\n- **Then:** Returns 401\n    \n\n### 💥 Server Failure\n\n- **Then:** Returns 500 with `code: 4502`\n    \n\n---\n\n## 📌 Notes\n\n- The `institution` is automatically inferred from the authenticated user\n    \n- Title does not need to be unique globally, only meaningful per institution\n    \n\n---\n\n## 🏷️ Tags\n\n`#Buildings` `#Create` `#POST`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/buildings/create/`\n    \n- **View:** `create_building_view`\n    \n- **Service:** `create_building()`\n    \n- **Repository:** `create_building()`\n    \n- **Serializer:** `CreateBuildingSerializer`\n    \n- **Model:** `Building`\n    \n\n---\n\nEndFragment"
+                                                        },
+                                                        "response": []
+                                                },
+                                                {
+                                                        "name": "Update Building",
+                                                        "request": {
+                                                                "method": "PUT",
+                                                                "header": [],
+                                                                "body": {
+                                                                        "mode": "formdata",
+                                                                        "formdata": [
+                                                                                {
+                                                                                        "key": "title",
+                                                                                        "value": "ساختمان جدید علوم پایه",
+                                                                                        "type": "text"
+                                                                                }
+                                                                        ]
+                                                                },
+                                                                "url": {
+                                                                        "raw": "{{base_url}}/api/locations/buildings/9/update/",
+                                                                        "host": [
+                                                                                "{{base_url}}"
+                                                                        ],
+                                                                        "path": [
+                                                                                "api",
+                                                                                "locations",
+                                                                                "buildings",
+                                                                                "9",
+                                                                                "update"
+                                                                        ]
+                                                                },
+                                                                "description": "StartFragment\n\n# 📄 `PUT - Update Building`\n\n**Folder:** `Buildings/`  \n**Request Name:** `PUT - Update Building`\n\n---\n\n## ✅ Description\n\nUpdates the title of a building that belongs to the authenticated user's institution. Only the `title` field is updatable.\n\n---\n\n## 🔗 Endpoint\n\n```\nPUT {{base_url}}/api/locations/buildings/<building_id>/update/\n\n ```\n\nReplace with the ID of the target building.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `building_id` | int | ✅ | ID of the building to update |\n\n---\n\n## 📥 Request Body (JSON)\n\n| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n| title | string | ❌ | New title for the building |\n\n### 🔸 Example:\n\n``` json\n{\n  \"title\": \"ساختمان پژوهشی ۲\"\n}\n\n ```\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2503,\n  \"message\": \"ساختمان با موفقیت به‌روزرسانی شد.\",\n  \"data\": {\n    \"building\": {\n      \"id\": 5,\n      \"title\": \"ساختمان پژوهشی ۲\",\n      \"institution\": 3\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 404 Not Found - Building Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4100,\n  \"message\": \"ساختمان مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### ❌ 400 Validation Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4102,\n  \"message\": \"اعتبارسنجی انجام نشد.\",\n  \"errors\": {\n    \"title\": [\"Ensure this field has no more than 255 characters.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing/Invalid Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4503,\n  \"message\": \"به‌روزرسانی ساختمان با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token and building ID + valid `title`\n    \n- **Then:** Returns 200 with updated building\n    \n\n### ❌ Building Not Found\n\n- **Then:** Returns 404 with code `4100`\n    \n\n### ❌ Validation Error\n\n- **When:** `title` too long or invalid\n    \n- **Then:** Returns 400\n    \n\n### 🚫 Unauthorized\n\n- **Then:** Returns 401\n    \n\n### 💥 Server Error\n\n- **Then:** Returns 500 with code `4503`\n    \n\n---\n\n## 📌 Notes\n\n- Only `title` can be updated\n    \n- Building must belong to the authenticated user's institution\n    \n\n---\n\n## 🏷️ Tags\n\n`#Buildings` `#Update` `#PUT`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/buildings//update/`\n    \n- **View:** `update_building_view`\n    \n- **Service:** `update_building()`\n    \n- **Repository:** `update_building_fields()`\n    \n- **Serializer:** `UpdateBuildingSerializer`\n    \n- **Model:** `Building`\n    \n\n---\n\nEndFragment"
+                                                        },
+                                                        "response": []
+                                                },
+                                                {
+                                                        "name": "Delete Building",
+                                                        "request": {
+                                                                "method": "DELETE",
+                                                                "header": [],
+                                                                "url": {
+                                                                        "raw": "{{base_url}}/api/locations/buildings/12/delete/",
+                                                                        "host": [
+                                                                                "{{base_url}}"
+                                                                        ],
+                                                                        "path": [
+                                                                                "api",
+                                                                                "locations",
+                                                                                "buildings",
+                                                                                "12",
+                                                                                "delete"
+                                                                        ]
+                                                                },
+                                                                "description": "StartFragment\n\n# 📄 `DELETE - Delete Building`\n\n**Folder:** `Buildings/`  \n**Request Name:** `DELETE - Delete Building`\n\n---\n\n## ✅ Description\n\nSoft deletes a building by its ID. The building must belong to the authenticated user's institution.\n\n---\n\n## 🔗 Endpoint\n\n```\nDELETE {{base_url}}/api/locations/buildings/<building_id>/delete/\n\n ```\n\nReplace with the numeric ID of the target building.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `building_id` | int | ✅ | ID of the building to delete |\n\n---\n\n## 📥 Request Body\n\n_None_\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2504,\n  \"message\": \"ساختمان با موفقیت حذف شد.\",\n  \"data\": {},\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 404 Not Found - Building Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4100,\n  \"message\": \"ساختمان مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4504,\n  \"message\": \"حذف ساختمان با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token and building ID exists\n    \n- **Then:** Returns 200 with confirmation message\n    \n\n### ❌ Building Not Found\n\n- **Then:** Returns 404\n    \n\n### 🚫 Unauthorized\n\n- **Then:** Returns 401\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with `code: 4504`\n    \n\n---\n\n## 📌 Notes\n\n- Only buildings belonging to the current user's institution can be deleted\n    \n- The deletion is soft (sets `is_deleted = True`)\n    \n\n---\n\n## 🏷️ Tags\n\n`#Buildings` `#Delete` `#DELETE`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/buildings//delete/`\n    \n- **View:** `delete_building_view`\n    \n- **Service:** `delete_building()`\n    \n- **Repository:** `soft_delete_building()`\n    \n- **Model:** `Building`\n    \n\n---\n\nEndFragment"
+                                                        },
+                                                        "response": []
+                                                }
+                                        ]
+                                },
+                                {
+                                        "name": "Classrooms",
+                                        "item": [
+                                                {
+                                                        "name": "List All Classrooms",
+                                                        "request": {
+                                                                "method": "GET",
+                                                                "header": [],
+                                                                "url": {
+                                                                        "raw": "{{base_url}}/api/locations/classrooms/all/",
+                                                                        "host": [
+                                                                                "{{base_url}}"
+                                                                        ],
+                                                                        "path": [
+                                                                                "api",
+                                                                                "locations",
+                                                                                "classrooms",
+                                                                                "all"
+                                                                        ]
+                                                                },
+                                                                "description": "StartFragment\n\n# 📄 `GET - List All Classrooms`\n\n**Folder:** `Classrooms/`  \n**Request Name:** `GET - List All Classrooms`\n\n---\n\n## ✅ Description\n\nReturns all active classrooms (`is_deleted = False`) across all buildings of the authenticated user's institution.\n\n---\n\n## 🔗 Endpoint\n\n```\nGET {{base_url}}/api/locations/classrooms/all/\n\n ```\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 📥 Request Body\n\n_None_\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2505,\n  \"message\": \"لیست کلاس‌ها با موفقیت دریافت شد.\",\n  \"data\": {\n    \"classrooms\": [\n      {\n        \"id\": 1,\n        \"title\": \"کلاس ۱۰۱\",\n        \"building\": 3\n      },\n      {\n        \"id\": 2,\n        \"title\": \"آزمایشگاه شبکه\",\n        \"building\": 4\n      }\n    ]\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### 🔒 401 Unauthorized - Missing Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 🔒 401 Unauthorized - Invalid Token\n\n``` json\n{\n  \"detail\": \"Invalid token.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4505,\n  \"message\": \"دریافت لیست کلاس‌ها با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token, classrooms exist in the institution\n    \n- **Then:** Returns 200 with classroom list\n    \n\n### ❌ No Classrooms Exist\n\n- **Then:** Returns:\n    \n\n``` json\n\"classrooms\": []\n\n ```\n\n### 🚫 Unauthorized - Missing or Invalid Token\n\n- **Then:** Returns 401\n    \n\n### ⛔ Forbidden\n\n- **Then:** Returns 403\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with code `4505`\n    \n\n---\n\n## 📌 Notes\n\n- All classrooms belong to buildings in the authenticated user's institution\n    \n- Only classrooms with `is_deleted = False` are returned\n    \n\n---\n\n## 🏷️ Tags\n\n`#Classrooms` `#List` `#Institution` `#GET`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/classrooms/all/`\n    \n- **View:** `list_all_classrooms_view`\n    \n- **Service:** `list_classrooms_for_institution()`\n    \n- **Repository:** `list_classrooms_by_institution()`\n    \n- **Serializer:** `ClassroomSerializer`\n    \n- **Model:** `Classroom`\n    \n\n---\n\nEndFragment"
+                                                        },
+                                                        "response": []
+                                                },
+                                                {
+                                                        "name": "List Classrooms by Building",
+                                                        "request": {
+                                                                "method": "GET",
+                                                                "header": [],
+                                                                "url": {
+                                                                        "raw": "{{base_url}}/api/locations/buildings/9/classrooms/",
+                                                                        "host": [
+                                                                                "{{base_url}}"
+                                                                        ],
+                                                                        "path": [
+                                                                                "api",
+                                                                                "locations",
+                                                                                "buildings",
+                                                                                "9",
+                                                                                "classrooms"
+                                                                        ]
+                                                                },
+                                                                "description": "StartFragment\n\n# 📄 `GET - List Classrooms by Building`\n\n**Folder:** `Classrooms/`  \n**Request Name:** `GET - List Classrooms by Building`\n\n---\n\n## ✅ Description\n\nReturns all active classrooms (`is_deleted = False`) under a specific building for the authenticated user's institution.\n\n---\n\n## 🔗 Endpoint\n\n```\nGET {{base_url}}/api/locations/buildings/<building_id>/classrooms/\n\n ```\n\nReplace with the numeric ID of the target building.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `building_id` | int | ✅ | ID of the target building |\n\n---\n\n## 📥 Request Body\n\n_None_\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2505,\n  \"message\": \"لیست کلاس‌ها با موفقیت دریافت شد.\",\n  \"data\": {\n    \"classrooms\": [\n      {\n        \"id\": 1,\n        \"title\": \"کلاس ۱۰۱\",\n        \"building\": 3\n      },\n      {\n        \"id\": 2,\n        \"title\": \"آزمایشگاه شبکه\",\n        \"building\": 3\n      }\n    ]\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 404 Not Found - Building Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4100,\n  \"message\": \"ساختمان مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 🔒 401 Unauthorized - Invalid Token\n\n``` json\n{\n  \"detail\": \"Invalid token.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4505,\n  \"message\": \"دریافت لیست کلاس‌ها با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token, classrooms exist under the specified building\n    \n- **Then:** Returns 200 with classrooms list\n    \n\n### ❌ No Classrooms Exist\n\n- **Then:** Returns:\n    \n\n``` json\n\"classrooms\": []\n\n ```\n\n### ❌ Building Not Found\n\n- **Then:** Returns 404 with code `4100`\n    \n\n### 🚫 Unauthorized - Missing Token\n\n- **Then:** Returns 401\n    \n\n### 🚫 Unauthorized - Invalid Token\n\n- **Then:** Returns 401\n    \n\n### ⛔ Forbidden\n\n- **Then:** Returns 403\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with code `4505`\n    \n\n---\n\n## 📌 Notes\n\n- All classrooms belong to the provided building ID and the authenticated user's institution\n    \n- Only classrooms with `is_deleted = False` are returned\n    \n\n---\n\n## 🏷️ Tags\n\n`#Classrooms` `#List` `#ByBuilding` `#GET`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/buildings//classrooms/`\n    \n- **View:** `list_classrooms_view`\n    \n- **Service:** `list_classrooms()`\n    \n- **Repository:** `list_classrooms_by_building()`\n    \n- **Serializer:** `ClassroomSerializer`\n    \n- **Model:** `Classroom`\n    \n\n---\n\nEndFragment"
+                                                        },
+                                                        "response": []
+                                                },
+                                                {
+                                                        "name": "Retrieve Classroom",
+                                                        "request": {
+                                                                "method": "GET",
+                                                                "header": [],
+                                                                "url": {
+                                                                        "raw": "{{base_url}}/api/locations/classrooms/1/",
+                                                                        "host": [
+                                                                                "{{base_url}}"
+                                                                        ],
+                                                                        "path": [
+                                                                                "api",
+                                                                                "locations",
+                                                                                "classrooms",
+                                                                                "1"
+                                                                        ]
+                                                                },
+                                                                "description": "StartFragment\n\n# 📄 `GET - Retrieve Classroom`\n\n**Folder:** `Classrooms/`  \n**Request Name:** `GET - Retrieve Classroom`\n\n---\n\n## ✅ Description\n\nRetrieves a specific classroom by its ID, **if it belongs to the authenticated user's institution**.\n\n---\n\n## 🔗 Endpoint\n\n```\nGET {{base_url}}/api/locations/classrooms/<classroom_id>/\n\n ```\n\nReplace with the numeric ID of the classroom to retrieve.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `classroom_id` | int | ✅ | ID of the classroom to retrieve |\n\n---\n\n## 📥 Request Body\n\n_None_\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2506,\n  \"message\": \"کلاس با موفقیت بازیابی شد.\",\n  \"data\": {\n    \"classroom\": {\n      \"id\": 4,\n      \"title\": \"کلاس ۱۰۱\",\n      \"building\": 2\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 404 Not Found - Classroom Not Found or Not Belonging to Institution\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4600,\n  \"message\": \"کلاس مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 🔒 401 Unauthorized - Invalid Token\n\n``` json\n{\n  \"detail\": \"Invalid token.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4601,\n  \"message\": \"بازیابی کلاس با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token and classroom exists in user's institution\n    \n- **Then:** Returns classroom object with 200\n    \n\n### ❌ Classroom Does Not Exist\n\n- **Then:** Returns 404 with code `4600`\n    \n\n### ❌ Classroom Not in User's Institution\n\n- **Then:** Returns 404 with code `4600`\n    \n\n### 🚫 Unauthorized - Missing or Invalid Token\n\n- **Then:** Returns 401\n    \n\n### ⛔ Forbidden\n\n- **Then:** Returns 403\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with code `4601`\n    \n\n---\n\n## 📌 Notes\n\n- Classroom must belong to one of the buildings of the authenticated user's institution\n    \n- Classroom must not be soft-deleted (`is_deleted = False`)\n    \n\n---\n\n## 🏷️ Tags\n\n`#Classrooms` `#Retrieve` `#GET`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/classrooms//`\n    \n- **View:** `retrieve_classroom_view`\n    \n- **Service:** `get_classroom_by_id_and_institution_or_404()`\n    \n- **Repository:** `get_classroom_by_id_and_institution()`\n    \n- **Serializer:** `ClassroomSerializer`\n    \n- **Model:** `Classroom`\n    \n\n---\n\nEndFragment"
+                                                        },
+                                                        "response": []
+                                                },
+                                                {
+                                                        "name": "Create Classroom",
+                                                        "request": {
+                                                                "method": "POST",
+                                                                "header": [],
+                                                                "body": {
+                                                                        "mode": "formdata",
+                                                                        "formdata": [
+                                                                                {
+                                                                                        "key": "title",
+                                                                                        "value": "آزمایشگاه شبکه",
+                                                                                        "type": "text"
+                                                                                }
+                                                                        ]
+                                                                },
+                                                                "url": {
+                                                                        "raw": "{{base_url}}/api/locations/buildings/9/classrooms/create/",
+                                                                        "host": [
+                                                                                "{{base_url}}"
+                                                                        ],
+                                                                        "path": [
+                                                                                "api",
+                                                                                "locations",
+                                                                                "buildings",
+                                                                                "9",
+                                                                                "classrooms",
+                                                                                "create"
+                                                                        ]
+                                                                },
+                                                                "description": "StartFragment\n\n# 📄 `POST - Create Classroom`\n\n**Folder:** `Classrooms/`  \n**Request Name:** `POST - Create Classroom`\n\n---\n\n## ✅ Description\n\nCreates a new classroom under a specific building belonging to the authenticated user's institution.\n\n---\n\n## 🔗 Endpoint\n\n```\nPOST {{base_url}}/api/locations/buildings/<building_id>/classrooms/create/\n\n ```\n\nReplace with the numeric ID of the target building.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `building_id` | int | ✅ | ID of the target building |\n\n---\n\n## 📥 Request Body\n\n**Content-Type:** `application/json`\n\n``` json\n{\n  \"title\": \"آزمایشگاه شبکه\"\n}\n\n ```\n\n| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n| title | string | ✅ | Name of the classroom to be added |\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `201 Created`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2504,\n  \"message\": \"کلاس با موفقیت ایجاد شد.\",\n  \"data\": {\n    \"classroom\": {\n      \"id\": 12,\n      \"title\": \"آزمایشگاه شبکه\",\n      \"building\": 3\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 400 Bad Request - Validation Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4102,\n  \"message\": \"خطا در اعتبارسنجی داده‌ها.\",\n  \"errors\": {\n    \"title\": [\"این فیلد نمی‌تواند خالی باشد.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n### ❌ 404 Not Found - Building Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4100,\n  \"message\": \"ساختمان مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### 🔒 401 Unauthorized - Invalid Token\n\n``` json\n{\n  \"detail\": \"Invalid token.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4602,\n  \"message\": \"ایجاد کلاس با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid token, valid building_id, valid data\n    \n- **Then:** Returns `201` with created classroom\n    \n\n### ❌ Validation Error\n\n- **When:** `title` is missing or blank\n    \n- **Then:** Returns 400 with code `4102`\n    \n\n### ❌ Building Not Found\n\n- **When:** building ID is invalid or not owned by user's institution\n    \n- **Then:** Returns 404 with code `4100`\n    \n\n### 🚫 Unauthorized - Missing/Invalid Token\n\n- **Then:** Returns 401\n    \n\n### ⛔ Forbidden\n\n- **Then:** Returns 403\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with code `4602`\n    \n\n---\n\n## 📌 Notes\n\n- Classroom is always tied to a building, and building must belong to the authenticated user's institution\n    \n\n---\n\n## 🏷️ Tags\n\n`#Classrooms` `#Create` `#POST`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/buildings//classrooms/create/`\n    \n- **View:** `create_classroom_view`\n    \n- **Service:** `create_classroom()`\n    \n- **Repository:** `create_classroom()`\n    \n- **Serializer:** `CreateClassroomSerializer`\n    \n- **Model:** `Classroom`\n    \n\n---\n\nEndFragment"
+                                                        },
+                                                        "response": []
+                                                },
+                                                {
+                                                        "name": "Update Classroom",
+                                                        "request": {
+                                                                "method": "PUT",
+                                                                "header": [],
+                                                                "body": {
+                                                                        "mode": "formdata",
+                                                                        "formdata": [
+                                                                                {
+                                                                                        "key": "title",
+                                                                                        "value": "کلاس جدید",
+                                                                                        "type": "text"
+                                                                                }
+                                                                        ]
+                                                                },
+                                                                "url": {
+                                                                        "raw": "{{base_url}}/api/locations/classrooms/2/update/",
+                                                                        "host": [
+                                                                                "{{base_url}}"
+                                                                        ],
+                                                                        "path": [
+                                                                                "api",
+                                                                                "locations",
+                                                                                "classrooms",
+                                                                                "2",
+                                                                                "update"
+                                                                        ]
+                                                                },
+                                                                "description": "StartFragment\n\n# 📄 `PUT - Update Classroom`\n\n**Folder:** `Classrooms/`  \n**Request Name:** `PUT - Update Classroom`\n\n---\n\n## ✅ Description\n\nUpdates the title of a specific classroom using its ID, **if it belongs to the authenticated user's institution**.\n\n---\n\n## 🔗 Endpoint\n\n```\nPUT {{base_url}}/api/locations/classrooms/<classroom_id>/update/\n\n ```\n\nReplace with the ID of the classroom to update.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `classroom_id` | int | ✅ | ID of the classroom to update |\n\n---\n\n## 📥 Request Body\n\n**Content-Type:** `application/json`\n\n``` json\n{\n  \"title\": \"کلاس جدید\"\n}\n\n ```\n\n| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n| title | string | ❌ | New title for the classroom |\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2507,\n  \"message\": \"کلاس با موفقیت به‌روزرسانی شد.\",\n  \"data\": {\n    \"classroom\": {\n      \"id\": 4,\n      \"title\": \"کلاس جدید\",\n      \"building\": 2\n    }\n  },\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 400 Bad Request - Validation Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4102,\n  \"message\": \"خطا در اعتبارسنجی داده‌ها.\",\n  \"errors\": {\n    \"title\": [\"این فیلد نمی‌تواند خالی باشد.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n### ❌ 404 Not Found - Classroom Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4600,\n  \"message\": \"کلاس مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing/Invalid Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4603,\n  \"message\": \"ویرایش کلاس با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid `classroom_id` and valid token and data\n    \n- **Then:** Returns 200 with updated classroom info\n    \n\n### ❌ Validation Error\n\n- **When:** title is invalid (e.g. blank or too long)\n    \n- **Then:** Returns 400 with `code: 4102`\n    \n\n### ❌ Classroom Not Found\n\n- **When:** classroom doesn’t exist or not under user's institution\n    \n- **Then:** Returns 404 with `code: 4600`\n    \n\n### 🚫 Unauthorized\n\n- **Then:** Returns 401\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with `code: 4603`\n    \n\n---\n\n## 📌 Notes\n\n- `building_id` is no longer required; classroom is resolved via institution linkage\n    \n- Partial updates are supported; only `title` can be updated\n    \n\n---\n\n## 🏷️ Tags\n\n`#Classrooms` `#Update` `#PUT`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/classrooms//update/`\n    \n- **View:** `update_classroom_view`\n    \n- **Service:** `update_classroom()`\n    \n- **Repository:** `get_classroom_by_id_and_institution()`\n    \n- **Serializer:** `UpdateClassroomSerializer`\n    \n- **Model:** `Classroom`\n    \n\n---\n\nEndFragment"
+                                                        },
+                                                        "response": []
+                                                },
+                                                {
+                                                        "name": "Delete Classroom",
+                                                        "request": {
+                                                                "method": "DELETE",
+                                                                "header": [],
+                                                                "url": {
+                                                                        "raw": "{{base_url}}/api/locations/classrooms/2/delete/",
+                                                                        "host": [
+                                                                                "{{base_url}}"
+                                                                        ],
+                                                                        "path": [
+                                                                                "api",
+                                                                                "locations",
+                                                                                "classrooms",
+                                                                                "2",
+                                                                                "delete"
+                                                                        ]
+                                                                },
+                                                                "description": "StartFragment\n\n# 📄 `DELETE - Delete Classroom`\n\n**Folder:** `Classrooms/`  \n**Request Name:** `DELETE - Delete Classroom`\n\n---\n\n## ✅ Description\n\nSoft-deletes a classroom (sets `is_deleted = true`) if it belongs to the authenticated user's institution.\n\n---\n\n## 🔗 Endpoint\n\n```\nDELETE {{base_url}}/api/locations/classrooms/<classroom_id>/delete/\n\n ```\n\nReplace with the ID of the classroom to delete.\n\n---\n\n## 🔐 Authentication\n\nThis endpoint **requires authentication**.\n\n- Header:\n    \n\n``` http\nAuthorization: Token {{token}}\n\n ```\n\n---\n\n## 🧾 Path Parameters\n\n| Name | Type | Required | Description |\n| --- | --- | --- | --- |\n| `classroom_id` | int | ✅ | ID of the classroom to delete |\n\n---\n\n## 📥 Request Body\n\n_None_\n\n---\n\n## 📤 Success Response\n\n**Status Code:** `200 OK`\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2508,\n  \"message\": \"کلاس با موفقیت حذف شد.\",\n  \"data\": {},\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## ⚠️ Error Responses\n\n### ❌ 404 Not Found - Classroom Not Found\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4600,\n  \"message\": \"کلاس مورد نظر یافت نشد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n### 🔒 401 Unauthorized - Missing/Invalid Token\n\n``` json\n{\n  \"detail\": \"Authentication credentials were not provided.\"\n}\n\n ```\n\n### ⛔ 403 Forbidden\n\n``` json\n{\n  \"detail\": \"You do not have permission to perform this action.\"\n}\n\n ```\n\n### 💥 500 Internal Server Error\n\n``` json\n{\n  \"success\": false,\n  \"code\": 4604,\n  \"message\": \"حذف کلاس با خطا مواجه شد.\",\n  \"errors\": [],\n  \"data\": {}\n}\n\n ```\n\n---\n\n## 🧪 Test Scenarios\n\n### ✅ Success Case\n\n- **When:** Valid classroom ID owned by the user's institution\n    \n- **Then:** Returns 200 with confirmation message\n    \n\n### ❌ Classroom Not Found\n\n- **When:** Invalid or unauthorized classroom ID\n    \n- **Then:** Returns 404 with `code: 4600`\n    \n\n### 🚫 Unauthorized\n\n- **Then:** Returns 401\n    \n\n### 💥 Internal Server Error\n\n- **Then:** Returns 500 with `code: 4604`\n    \n\n---\n\n## 📌 Notes\n\n- This is a _soft delete_ operation — classroom remains in DB but flagged as deleted\n    \n- Operation is only allowed if the classroom belongs to the current user's institution\n    \n- `building_id` is not required anymore for deletion\n    \n\n---\n\n## 🏷️ Tags\n\n`#Classrooms` `#Delete` `#SoftDelete` `#DELETE`\n\n---\n\n## 🛠️ Implementation Reference\n\n- **URL:** `/api/locations/classrooms//delete/`\n    \n- **View:** `delete_classroom_view`\n    \n- **Service:** `delete_classroom()` + `get_classroom_instance_by_institution_or_404()`\n    \n- **Repository:** `soft_delete_classroom()`\n    \n- **Model:** `Classroom`\n    \n\n---\n\nEndFragment"
+                                                        },
+                                                        "response": []
+                                                }
+                                        ]
+                                }
+                        ]
+                }
+        ],
+        "auth": {
+                "type": "apikey",
+                "apikey": [
+                        {
+                                "key": "value",
+                                "value": "Token {{token}}",
+                                "type": "string"
+                        },
+                        {
+                                "key": "key",
+                                "value": "Authorization",
+                                "type": "string"
+                        }
+                ]
+        },
+        "event": [
+                {
+                        "listen": "prerequest",
+                        "script": {
+                                "type": "text/javascript",
+                                "packages": {},
+                                "exec": [
+                                        ""
+                                ]
+                        }
+                },
+                {
+                        "listen": "test",
+                        "script": {
+                                "type": "text/javascript",
+                                "packages": {},
+                                "exec": [
+                                        ""
+                                ]
+                        }
+                }
+        ]
 }


### PR DESCRIPTION
## Summary
- Update Postman collection URLs to use `{{base_url}}` as the host
- Define complete path arrays without empty segments
- Align `raw` URLs with host and path (e.g., `{{base_url}}/api/...`)

## Testing
- `python -m pytest` *(fails: Requested setting REST_FRAMEWORK, but settings are not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cd76b054832ab8f2cacf51fe6202