### PR TITLE
Configure ClassSession admin listing

### DIFF
--- a/schedules/admin.py
+++ b/schedules/admin.py
@@ -1,3 +1,21 @@
 from django.contrib import admin
 
-# Register your models here.
+from schedules.models.class_session_model import ClassSession
+
+
+class ClassSessionAdmin(admin.ModelAdmin):
+    list_display = (
+        "course",
+        "professor",
+        "classroom",
+        "day_of_week",
+        "start_time",
+        "end_time",
+        "week_type",
+    )
+    list_filter = ("institution", "semester", "day_of_week", "week_type")
+    search_fields = ("course__title", "professor__last_name", "classroom__title")
+    autocomplete_fields = ("course", "professor", "classroom", "semester")
+
+
+admin.site.register(ClassSession, ClassSessionAdmin)


### PR DESCRIPTION
## Summary
- import ClassSession into the admin module
- add a ClassSessionAdmin with list displays, filters, search, and autocomplete
- register ClassSession with the new admin configuration

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68caed52a9ec832aabd1ec6a1d8862a1