### PR TITLE
Handle preview link for unsaved display screens

### DIFF
--- a/displays/admin.py
+++ b/displays/admin.py
@@ -74,6 +74,8 @@ class DisplayScreenAdmin(admin.ModelAdmin):
 
     @admin.display(description="لینک عمومی")
     def preview_link(self, obj: DisplayScreen) -> str:
+        if obj is None or not getattr(obj, "pk", None) or not getattr(obj, "slug", None):
+            return "Save to generate preview"
         url = reverse("public-displays:public-display", args=[obj.slug])
         return format_html('<a href="{}" target="_blank">{}</a>', url, url)
 


### PR DESCRIPTION
## Summary
- return a friendly placeholder from `DisplayScreenAdmin.preview_link` when the object is new or missing a slug
- preserve the existing preview link behavior for saved screens with valid slugs

## Testing
- python manage.py shell -c "from django.contrib.admin.sites import AdminSite; from displays.admin import DisplayScreenAdmin; from displays.models import DisplayScreen; from institutions.models import Institution; site = AdminSite(); admin = DisplayScreenAdmin(DisplayScreen, site); print('None ->', admin.preview_link(obj=None)); inst = Institution.objects.first(); unsaved = DisplayScreen(institution=inst, title='Test Preview'); print('Unsaved ->', admin.preview_link(obj=unsaved)); unsaved.pk = 1; unsaved.slug = 'test-preview'; print('Simulated saved ->', admin.preview_link(obj=unsaved))"

------
https://chatgpt.com/codex/tasks/task_e_68cb941c4b90832a8d96c5e64fa2d4a7