### PR TITLE
Optimize display filter migration

### DIFF
--- a/displays/migrations/0003_displayscreen_filters_delete_displayfilter.py
+++ b/displays/migrations/0003_displayscreen_filters_delete_displayfilter.py
@@ -7,10 +7,12 @@ def migrate_filters_to_json(apps, schema_editor):
     DisplayScreen = apps.get_model("displays", "DisplayScreen")
     DisplayFilter = apps.get_model("displays", "DisplayFilter")
 
-    for screen in DisplayScreen.objects.all():
+    for screen_id in DisplayScreen.objects.values_list("id", flat=True):
         filter_payload = []
         filters = (
-            DisplayFilter.objects.filter(display_screen=screen, is_deleted=False)
+            DisplayFilter.objects.filter(
+                display_screen_id=screen_id, is_deleted=False
+            )
             .order_by("position", "id")
         )
         for filter_obj in filters:
@@ -35,7 +37,7 @@ def migrate_filters_to_json(apps, schema_editor):
                 }
             )
         if filter_payload:
-            DisplayScreen.objects.filter(pk=screen.pk).update(filters=filter_payload)
+            DisplayScreen.objects.filter(pk=screen_id).update(filters=filter_payload)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
## Summary
- iterate DisplayScreen IDs when migrating filters to avoid instantiating full models
- persist filter payloads with a queryset update on the DisplayScreen model

## Testing
- python manage.py migrate

------
https://chatgpt.com/codex/tasks/task_e_68cbf4e3f794832a94cf85c0fb6286fc