### PR TITLE
Fix Update Professor Postman request

### DIFF
--- a/Unischedule API.postman_collection.json
+++ b/Unischedule API.postman_collection.json
@@ -319,41 +319,32 @@
         {
           "name": "Update Professor",
           "request": {
-            "method": "POST",
-            "header": [],
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
             "body": {
-              "mode": "formdata",
-              "formdata": [
-                {
-                  "key": "first_name",
-                  "value": "عرفان",
-                  "type": "text"
-                },
-                {
-                  "key": "last_name",
-                  "value": "رضایی2",
-                  "type": "text"
-                },
-                {
-                  "key": "national_code",
-                  "value": "0912345610",
-                  "type": "text"
-                },
-                {
-                  "key": "phone_number",
-                  "value": "09033483116",
-                  "type": "text"
+              "mode": "raw",
+              "raw": "{\n  \"first_name\": \"Ali\",\n  \"last_name\": \"Ahmadi\",\n  \"phone_number\": \"09123456789\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
                 }
-              ]
+              }
             },
             "url": {
-              "raw": "{{base_url}}api/professors/create/",
+              "raw": "{{base_url}}/api/professors/{{professor_id}}/update/",
               "host": [
-                "{{base_url}}api"
+                "{{base_url}}"
               ],
               "path": [
+                "api",
                 "professors",
-                "create",
+                "{{professor_id}}",
+                "update",
                 ""
               ]
             },


### PR DESCRIPTION
## Summary
- update the Update Professor request in the Postman collection to use the correct PUT method and endpoint
- send a JSON body that matches the project serializer and include the appropriate content type header

## Testing
- not run (not required for JSON documentation changes)


------
https://chatgpt.com/codex/tasks/task_e_68d03f88f9d8832ab801722661744d15