### PR TITLE
Clean Postman collection events

### DIFF
--- a/Unischedule API.postman_collection.json
+++ b/Unischedule API.postman_collection.json
@@ -1005,16 +1005,23 @@
               "listen": "test",
               "script": {
                 "exec": [
-                  ""
+                  "pm.test(\"Status code is 201\", function () {",
+                  "    pm.response.to.have.status(201);",
+                  "});",
+                  "let jsonData = {};",
+                  "try {",
+                  "    jsonData = pm.response.json();",
+                  "} catch (error) {",
+                  "    console.warn(\"Response is not JSON\", error);",
+                  "}",
+                  "if (jsonData && jsonData.data && jsonData.data.class_session) {",
+                  "    pm.collectionVariables.set(\"schedule_id\", jsonData.data.class_session.id);",
+                  "}",
+                  "pm.test(\"Schedule payload is returned\", function () {",
+                  "    pm.expect(jsonData).to.have.property(\"data\");",
+                  "    pm.expect(jsonData.data).to.have.property(\"class_session\");",
+                  "});"
                 ],
-                "type": "text/javascript",
-                "packages": {}
-              }
-            },
-            {
-              "listen": "prerequest",
-              "script": {
-                "packages": {},
                 "type": "text/javascript"
               }
             }
@@ -3145,9 +3152,13 @@
       "listen": "prerequest",
       "script": {
         "type": "text/javascript",
-        "packages": {},
         "exec": [
-          ""
+          "const tokenFromCollection = pm.collectionVariables.get(\"token\");",
+          "const tokenFromEnv = pm.environment.get(\"token\");",
+          "const token = tokenFromCollection || tokenFromEnv;",
+          "if (token) {",
+          "    pm.request.headers.upsert({ key: \"Authorization\", value: \"Token \" + token });",
+          "}"
         ]
       }
     },
@@ -3155,9 +3166,22 @@
       "listen": "test",
       "script": {
         "type": "text/javascript",
-        "packages": {},
         "exec": [
-          ""
+          "if (!pm.response) {",
+          "    return;",
+          "}",
+          "let jsonData = null;",
+          "try {",
+          "    jsonData = pm.response.json();",
+          "} catch (error) {",
+          "    jsonData = null;",
+          "}",
+          "if (jsonData && jsonData.data && jsonData.data.token) {",
+          "    pm.collectionVariables.set(\"token\", jsonData.data.token);",
+          "}",
+          "pm.test('Status code is numeric', function () {",
+          "    pm.expect(pm.response.code).to.be.a(\"number\");",
+          "});"
         ]
       }
     }


### PR DESCRIPTION
## Summary
- remove deprecated script.packages entries across the Postman collection events
- replace the empty Create Schedule test script with real assertions that persist the created session id
- add collection-level pre-request and test scripts to auto-manage Authorization headers and capture login tokens

## Testing
- python - <<'PY'
import json
from pathlib import Path

path = Path('Unischedule API.postman_collection.json')
data = json.loads(path.read_text())

issues = []

def check_events(node, context='root'):
    if isinstance(node, dict):
        if 'event' in node and isinstance(node['event'], list):
            for idx, event in enumerate(node['event']):
                if not isinstance(event, dict):
                    issues.append((context, f'Event at index {idx} is not a dict'))
                    continue
                script = event.get('script')
                if not isinstance(script, dict):
                    issues.append((context, f'Event {idx} missing script dict'))
                    continue
                if 'type' not in script or 'exec' not in script:
                    issues.append((context, f'Event {idx} missing required keys: {sorted(script.keys())}'))
                elif not any(line.strip() for line in script['exec']):
                    issues.append((context, f'Event {idx} has empty exec'))
        for key, value in node.items():
            check_events(value, f'{context}.{key}')
    elif isinstance(node, list):
        for i, item in enumerate(node):
            check_events(item, f'{context}[{i}]')

check_events(data)

if issues:
    for ctx, msg in issues:
        print(ctx, '->', msg)
    raise SystemExit(1)
print('All events have valid script structure.')
PY

------
https://chatgpt.com/codex/tasks/task_e_68d1a3a398b8832aa9725163bb52abe8