### PR TITLE
Fix Postman collection import by removing empty form-data bodies

### DIFF
--- a/Unischedule API.postman_collection.json
+++ b/Unischedule API.postman_collection.json
@@ -236,10 +236,6 @@
                 "value": "Token {{token}}"
               }
             ],
-            "body": {
-              "mode": "formdata",
-              "formdata": []
-            },
             "url": {
               "raw": "{{base_url}}/api/semesters/11/activate/",
               "host": [
@@ -980,10 +976,6 @@
                 "value": "Token {{token}}"
               }
             ],
-            "body": {
-              "mode": "formdata",
-              "formdata": []
-            },
             "url": {
               "raw": "{{base_url}}/api/schedules/",
               "host": [


### PR DESCRIPTION
## Summary
- remove empty form-data bodies from the Set Active Semester and List Schedules requests in the Postman collection to avoid empty form-data payloads

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1ba7b0d28832a884e29f131b92324