### PR TITLE
Add password change API and tests

### DIFF
--- a/accounts/serializers/__init__.py
+++ b/accounts/serializers/__init__.py
@@ -1,1 +1,2 @@
 from .login_serializer import *
+from .change_password_serializer import *

--- a/accounts/serializers/change_password_serializer.py
+++ b/accounts/serializers/change_password_serializer.py
@@ -1,0 +1,35 @@
+from django.contrib.auth import password_validation
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import serializers
+
+
+class ChangePasswordSerializer(serializers.Serializer):
+    old_password = serializers.CharField(write_only=True)
+    new_password = serializers.CharField(write_only=True)
+    confirm_new_password = serializers.CharField(write_only=True)
+
+    def validate(self, attrs):
+        old_password = attrs.get("old_password")
+        new_password = attrs.get("new_password")
+        confirm_new_password = attrs.get("confirm_new_password")
+        user = self.context.get("user")
+
+        errors = {}
+
+        if new_password != confirm_new_password:
+            errors["confirm_new_password"] = ["رمز عبور جدید و تکرار آن یکسان نیستند."]
+
+        if old_password and new_password and old_password == new_password:
+            errors.setdefault("new_password", []).append(
+                "رمز عبور جدید نباید با رمز عبور فعلی یکسان باشد."
+            )
+
+        try:
+            password_validation.validate_password(new_password, user=user)
+        except DjangoValidationError as exc:
+            errors.setdefault("new_password", []).extend(exc.messages)
+
+        if errors:
+            raise serializers.ValidationError(errors)
+
+        return attrs

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -1,3 +1,96 @@
+from django.contrib.auth import get_user_model
+from rest_framework import status
+from rest_framework.test import APIClient
 from django.test import TestCase
 
-# Create your tests here.
+from unischedule.core.error_codes import ErrorCodes
+from unischedule.core.success_codes import SuccessCodes
+
+
+class ChangePasswordAPITestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = get_user_model().objects.create_user(
+            username="testuser",
+            email="test@example.com",
+            password="OldPassword123",
+        )
+        self.url = "/api/auth/change-password/"
+        self.client.force_authenticate(user=self.user)
+
+    def test_change_password_success(self):
+        payload = {
+            "old_password": "OldPassword123",
+            "new_password": "NewPassword123!",
+            "confirm_new_password": "NewPassword123!",
+        }
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(response.data["success"])
+        self.assertEqual(response.data["code"], SuccessCodes.PASSWORD_CHANGE_SUCCESS["code"])
+        self.assertEqual(response.data["message"], SuccessCodes.PASSWORD_CHANGE_SUCCESS["message"])
+
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password(payload["new_password"]))
+
+    def test_change_password_incorrect_current_password(self):
+        payload = {
+            "old_password": "WrongPassword",
+            "new_password": "AnotherPassword123",
+            "confirm_new_password": "AnotherPassword123",
+        }
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, ErrorCodes.PASSWORD_INCORRECT["status_code"])
+        self.assertFalse(response.data["success"])
+        self.assertEqual(response.data["code"], ErrorCodes.PASSWORD_INCORRECT["code"])
+        self.assertEqual(response.data["message"], ErrorCodes.PASSWORD_INCORRECT["message"])
+
+    def test_change_password_mismatch(self):
+        payload = {
+            "old_password": "OldPassword123",
+            "new_password": "NewPassword123",
+            "confirm_new_password": "MismatchPassword123",
+        }
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, ErrorCodes.VALIDATION_FAILED["status_code"])
+        self.assertFalse(response.data["success"])
+        self.assertEqual(response.data["code"], ErrorCodes.VALIDATION_FAILED["code"])
+        self.assertIn("confirm_new_password", response.data["errors"])
+
+    def test_change_password_same_as_old(self):
+        payload = {
+            "old_password": "OldPassword123",
+            "new_password": "OldPassword123",
+            "confirm_new_password": "OldPassword123",
+        }
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, ErrorCodes.VALIDATION_FAILED["status_code"])
+        self.assertFalse(response.data["success"])
+        self.assertIn("new_password", response.data["errors"])
+
+    def test_change_password_does_not_meet_policy(self):
+        payload = {
+            "old_password": "OldPassword123",
+            "new_password": "short",
+            "confirm_new_password": "short",
+        }
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, ErrorCodes.VALIDATION_FAILED["status_code"])
+        self.assertFalse(response.data["success"])
+        self.assertIn("new_password", response.data["errors"])
+        self.assertTrue(
+            any(
+                "short" in message.lower() or "at least" in message.lower()
+                for message in response.data["errors"]["new_password"]
+            )
+        )

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -4,5 +4,6 @@ from accounts import views
 
 urlpatterns = [
     path("login/", views.login_view, name="login"),
-    path("logout/", views.logout_view, name="logout")
+    path("logout/", views.logout_view, name="logout"),
+    path("change-password/", views.change_password_view, name="change-password"),
 ]

--- a/accounts/views/auth_view.py
+++ b/accounts/views/auth_view.py
@@ -2,7 +2,7 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework import status
 
-from accounts.services import login_user, logout_user
+from accounts.services import login_user, logout_user, change_user_password
 
 from unischedule.core.base_response import BaseResponse
 from unischedule.core.success_codes import SuccessCodes
@@ -69,4 +69,33 @@ def logout_view(request):
             code=ErrorCodes.LOGOUT_FAILED["code"],
             status_code=ErrorCodes.LOGOUT_FAILED["status_code"],
             errors=ErrorCodes.LOGOUT_FAILED["errors"]
+        )
+
+
+@api_view(["POST"])
+@permission_classes([IsAuthenticated])
+def change_password_view(request):
+    """POST - Change the authenticated user's password."""
+    try:
+        change_user_password(request.user, request.data)
+        return BaseResponse.success(
+            message=SuccessCodes.PASSWORD_CHANGE_SUCCESS["message"],
+            code=SuccessCodes.PASSWORD_CHANGE_SUCCESS["code"],
+            data=SuccessCodes.PASSWORD_CHANGE_SUCCESS.get("data", {}),
+            status_code=status.HTTP_200_OK
+        )
+    except CustomValidationError as e:
+        return BaseResponse.error(
+            message=e.detail["message"],
+            code=e.detail["code"],
+            status_code=e.status_code,
+            errors=e.detail["errors"],
+            data=e.detail["data"]
+        )
+    except Exception:
+        return BaseResponse.error(
+            message=ErrorCodes.PASSWORD_CHANGE_FAILED["message"],
+            code=ErrorCodes.PASSWORD_CHANGE_FAILED["code"],
+            status_code=ErrorCodes.PASSWORD_CHANGE_FAILED["status_code"],
+            errors=ErrorCodes.PASSWORD_CHANGE_FAILED["errors"]
         )

--- a/unischedule/core/error_codes.py
+++ b/unischedule/core/error_codes.py
@@ -278,3 +278,17 @@ class ErrorCodes:
         "errors": [],
         "data": {},
     }
+    PASSWORD_INCORRECT = {
+        "code": "4704",
+        "message": "رمز عبور فعلی نادرست است.",
+        "status_code": status.HTTP_400_BAD_REQUEST,
+        "errors": ["The current password provided is incorrect."],
+        "data": {},
+    }
+    PASSWORD_CHANGE_FAILED = {
+        "code": "4705",
+        "message": "تغییر رمز عبور با خطا مواجه شد.",
+        "status_code": status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "errors": [],
+        "data": {},
+    }

--- a/unischedule/core/success_codes.py
+++ b/unischedule/core/success_codes.py
@@ -203,3 +203,8 @@ class SuccessCodes:
         "code": 2201,
         "message": "خروج از حساب با موفقیت انجام شد."
     }
+    PASSWORD_CHANGE_SUCCESS = {
+        "code": 2002,
+        "message": "رمز عبور با موفقیت تغییر کرد.",
+        "data": {},
+    }


### PR DESCRIPTION
## Summary
- add a serializer to validate password change requests against Django policies
- extend the auth service, views, and routing with a change-password endpoint
- define new success/error codes and cover password change scenarios with tests

## Testing
- python manage.py test accounts

------
https://chatgpt.com/codex/tasks/task_e_68db95dac2d4832a9d207beed798c11c