### PR TITLE
Add Postman entry for account password change

### DIFF
--- a/Unischedule API.postman_collection.json
+++ b/Unischedule API.postman_collection.json
@@ -620,6 +620,210 @@
 				}
 			]
 		},
+                {
+                        "name": "Accounts",
+                        "item": [
+                                {
+                                        "name": "POST - Change Password",
+                                        "event": [
+                                                {
+                                                        "listen": "test",
+                                                        "script": {
+                                                                "type": "text/javascript",
+                                                                "exec": [
+                                                                        "pm.test(\"Status code is 200 or 400\", function () {",
+                                                                        "    pm.expect([200, 400]).to.include(pm.response.code);",
+                                                                        "});",
+                                                                        "",
+                                                                        "if (pm.response.code === 200) {",
+                                                                        "    const jsonData = pm.response.json();",
+                                                                        "    pm.test(\"Password change succeeded\", function () {",
+                                                                        "        pm.expect(jsonData.success).to.be.true;",
+                                                                        "        pm.expect(jsonData.code).to.eql(2002);",
+                                                                        "    });",
+                                                                        "} else if (pm.response.code === 400) {",
+                                                                        "    const jsonData = pm.response.json();",
+                                                                        "    pm.test(\"Password change error response\", function () {",
+                                                                        "        pm.expect(jsonData.success).to.be.false;",
+                                                                        "        pm.expect(jsonData.code).to.be.oneOf([\"4000\", \"4704\"]);",
+                                                                        "    });",
+                                                                        "}"
+                                                                ]
+                                                        }
+                                                }
+                                        ],
+                                        "request": {
+                                                "method": "POST",
+                                                "header": [
+                                                        {
+                                                                "key": "Authorization",
+                                                                "value": "Token {{token}}",
+                                                                "type": "text"
+                                                        },
+                                                        {
+                                                                "key": "Content-Type",
+                                                                "value": "multipart/form-data",
+                                                                "type": "text"
+                                                        }
+                                                ],
+                                                "body": {
+                                                        "mode": "formdata",
+                                                        "formdata": [
+                                                                {
+                                                                        "key": "old_password",
+                                                                        "value": "OldPassword123!",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "new_password",
+                                                                        "value": "NewPassword456!",
+                                                                        "type": "text"
+                                                                },
+                                                                {
+                                                                        "key": "confirm_new_password",
+                                                                        "value": "NewPassword456!",
+                                                                        "type": "text"
+                                                                }
+                                                        ]
+                                                },
+                                                "url": {
+                                                        "raw": "{{base_url}}api/accounts/change-password/",
+                                                        "host": [
+                                                                "{{base_url}}api"
+                                                        ],
+                                                        "path": [
+                                                                "accounts",
+                                                                "change-password",
+                                                                ""
+                                                        ]
+                                                },
+                                                "description": "StartFragment\n\n# \ud83d\udcc4 `POST - Change Password`\n\n**Folder:** `Accounts/`  \\n**Request Name:** `POST - Change Password`\n\n---\n\n## \u2705 Description\n\nAllows an authenticated account to securely change its password using the current password and a confirmed new password.\n\n---\n\n## \ud83d\udd17 Endpoint\n\n```\nPOST {{base_url}}/api/accounts/change-password/\n\n ```\n\n---\n\n## \ud83d\udd10 Authentication\n\nToken authentication required. Include `Authorization: Token {{token}}`.\n\n---\n\n## \ud83d\udcc5 Request Body (form-data)\n\n| Field | Type | Required | Description |\n| --- | --- | --- | --- |\n| `old_password` | string | \u2705 | Current account password |\n| `new_password` | string | \u2705 | Desired new password that meets policy requirements |\n| `confirm_new_password` | string | \u2705 | Must exactly match `new_password` |\n\n``` json\n{\n  \"old_password\": \"OldPassword123!\",\n  \"new_password\": \"NewPassword456!\",\n  \"confirm_new_password\": \"NewPassword456!\"\n}\n\n ```\n\n---\n\n## \ud83d\udce4 Success Response\n\n**Status Code:** `200 OK`\n\nUses `SuccessCodes.PASSWORD_CHANGE_SUCCESS`.\n\n``` json\n{\n  \"success\": true,\n  \"code\": 2002,\n  \"message\": \"\u0631\u0645\u0632 \u0639\u0628\u0648\u0631 \u0628\u0627 \u0645\u0648\u0641\u0642\u06cc\u062a \u062a\u063a\u06cc\u06cc\u0631 \u06a9\u0631\u062f.\",\n  \"data\": {},\n  \"warnings\": [],\n  \"meta\": {}\n}\n\n ```\n\n---\n\n## \u26a0\ufe0f Error Responses\n\n### \u274c Validation Failed\n\n**Status Code:** `400 BAD REQUEST`\n\nTriggered when new password confirmation mismatches or violates policy. Maps to `ErrorCodes.VALIDATION_FAILED`.\n\n``` json\n{\n  \"success\": false,\n  \"code\": \"4000\",\n  \"message\": \"\u0627\u0637\u0644\u0627\u0639\u0627\u062a \u0648\u0627\u0631\u062f \u0634\u062f\u0647 \u0646\u0627\u0645\u0639\u062a\u0628\u0631 \u0627\u0633\u062a.\",\n  \"errors\": {\n    \"confirm_new_password\": [\"The two password fields didn\\u2019t match.\"]\n  },\n  \"data\": {}\n}\n\n ```\n\n### \u274c Incorrect Current Password\n\n**Status Code:** `400 BAD REQUEST`\n\nUses `ErrorCodes.PASSWORD_INCORRECT`.\n\n``` json\n{\n  \"success\": false,\n  \"code\": \"4704\",\n  \"message\": \"\u0631\u0645\u0632 \u0639\u0628\u0648\u0631 \u0641\u0639\u0644\u06cc \u0646\u0627\u062f\u0631\u0633\u062a \u0627\u0633\u062a.\",\n  \"errors\": [\"The current password provided is incorrect.\"],\n  \"data\": {}\n}\n\n ```\n\n### \u274c Missing Authentication Token\n\n**Status Code:** `401 UNAUTHORIZED`\n\nReturned when `Authorization` header is absent or invalid.\n\n### \u274c Institution Missing\n\n**Status Code:** `403 FORBIDDEN`\n\nReturned when the authenticated user is not associated with an institution (if enforced). Maps to `ErrorCodes.INSTITUTION_REQUIRED`.\n\n### \ud83d\udca5 Internal Server Error\n\n**Status Code:** `500 INTERNAL SERVER ERROR`\n\nUnexpected failure while changing the password. Maps to `ErrorCodes.PASSWORD_CHANGE_FAILED`.\n\n---\n\n## \ud83e\uddea Key Test Scenarios\n\n### \u2705 Successful Password Change\n- Provide correct `old_password` and matching strong new password.\n- Expect `200` with code `2002`.\n\n### \u274c Incorrect Current Password\n- Provide wrong `old_password`.\n- Expect `400` with `ErrorCodes.PASSWORD_INCORRECT`.\n\n### \u274c Validation Errors\n- Provide mismatched confirmation or weak password.\n- Expect `400` with validation details.\n\n### \u26a0\ufe0f Missing Token\n- Omit the `Authorization` header to trigger `401`.\n\n### \u26a0\ufe0f Institution Enforcement\n- Attempt when the user lacks an institution to trigger `403`.\n\n---\n\n## \ud83d\udccc Notes\n\n- After success, prompt the user to re-authenticate with the new credentials.\n- Update stored credentials (e.g., password managers) immediately.\n\n---\n\n## \ud83d\udd27 Implementation Reference\n\n- **View:** `accounts.views.change_password_view`\n- **Serializer:** `ChangePasswordSerializer`\n- **Success Code:** `SuccessCodes.PASSWORD_CHANGE_SUCCESS`\n- **Error Codes:** `ErrorCodes.PASSWORD_INCORRECT`, `ErrorCodes.VALIDATION_FAILED`, `ErrorCodes.PASSWORD_CHANGE_FAILED`\n\nEndFragment"
+                                        },
+                                        "response": [
+                                                {
+                                                        "name": "200 OK - Password Changed",
+                                                        "originalRequest": {
+                                                                "method": "POST",
+                                                                "header": [
+                                                                        {
+                                                                                "key": "Authorization",
+                                                                                "value": "Token {{token}}",
+                                                                                "type": "text"
+                                                                        },
+                                                                        {
+                                                                                "key": "Content-Type",
+                                                                                "value": "multipart/form-data",
+                                                                                "type": "text"
+                                                                        }
+                                                                ],
+                                                                "body": {
+                                                                        "mode": "formdata",
+                                                                        "formdata": [
+                                                                                {
+                                                                                        "key": "old_password",
+                                                                                        "value": "OldPassword123!",
+                                                                                        "type": "text"
+                                                                                },
+                                                                                {
+                                                                                        "key": "new_password",
+                                                                                        "value": "NewPassword456!",
+                                                                                        "type": "text"
+                                                                                },
+                                                                                {
+                                                                                        "key": "confirm_new_password",
+                                                                                        "value": "NewPassword456!",
+                                                                                        "type": "text"
+                                                                                }
+                                                                        ]
+                                                                },
+                                                                "url": {
+                                                                        "raw": "{{base_url}}api/accounts/change-password/",
+                                                                        "host": [
+                                                                                "{{base_url}}api"
+                                                                        ],
+                                                                        "path": [
+                                                                                "accounts",
+                                                                                "change-password",
+                                                                                ""
+                                                                        ]
+                                                                }
+                                                        },
+                                                        "status": "OK",
+                                                        "code": 200,
+                                                        "_postman_previewlanguage": "json",
+                                                        "header": [
+                                                                {
+                                                                        "key": "Content-Type",
+                                                                        "value": "application/json"
+                                                                }
+                                                        ],
+                                                        "cookie": [],
+                                                        "body": "{\n    \"success\": true,\n    \"code\": 2002,\n    \"message\": \"\\u0631\\u0645\\u0632 \\u0639\\u0628\\u0648\\u0631 \\u0628\\u0627 \\u0645\\u0648\\u0641\\u0642\\u06cc\\u062a \\u062a\\u063a\\u06cc\\u06cc\\u0631 \\u06a9\\u0631\\u062f.\",\n    \"data\": {},\n    \"warnings\": [],\n    \"meta\": {}\n}"
+                                                },
+                                                {
+                                                        "name": "400 BAD REQUEST - Incorrect Current Password",
+                                                        "originalRequest": {
+                                                                "method": "POST",
+                                                                "header": [
+                                                                        {
+                                                                                "key": "Authorization",
+                                                                                "value": "Token {{token}}",
+                                                                                "type": "text"
+                                                                        },
+                                                                        {
+                                                                                "key": "Content-Type",
+                                                                                "value": "multipart/form-data",
+                                                                                "type": "text"
+                                                                        }
+                                                                ],
+                                                                "body": {
+                                                                        "mode": "formdata",
+                                                                        "formdata": [
+                                                                                {
+                                                                                        "key": "old_password",
+                                                                                        "value": "OldPassword123!",
+                                                                                        "type": "text"
+                                                                                },
+                                                                                {
+                                                                                        "key": "new_password",
+                                                                                        "value": "NewPassword456!",
+                                                                                        "type": "text"
+                                                                                },
+                                                                                {
+                                                                                        "key": "confirm_new_password",
+                                                                                        "value": "NewPassword456!",
+                                                                                        "type": "text"
+                                                                                }
+                                                                        ]
+                                                                },
+                                                                "url": {
+                                                                        "raw": "{{base_url}}api/accounts/change-password/",
+                                                                        "host": [
+                                                                                "{{base_url}}api"
+                                                                        ],
+                                                                        "path": [
+                                                                                "accounts",
+                                                                                "change-password",
+                                                                                ""
+                                                                        ]
+                                                                }
+                                                        },
+                                                        "status": "Bad Request",
+                                                        "code": 400,
+                                                        "_postman_previewlanguage": "json",
+                                                        "header": [
+                                                                {
+                                                                        "key": "Content-Type",
+                                                                        "value": "application/json"
+                                                                }
+                                                        ],
+                                                        "cookie": [],
+                                                        "body": "{\n    \"success\": false,\n    \"code\": \"4704\",\n    \"message\": \"\\u0631\\u0645\\u0632 \\u0639\\u0628\\u0648\\u0631 \\u0641\\u0639\\u0644\\u06cc \\u0646\\u0627\\u062f\\u0631\\u0633\\u062a \\u0627\\u0633\\u062a.\",\n    \"errors\": [\n        \"The current password provided is incorrect.\"\n    ],\n    \"data\": {}\n}"
+                                                }
+                                        ]
+                                }
+                        ]
+                },
 		{
 			"name": "Semesters",
 			"item": [


### PR DESCRIPTION
## Summary
- add a dedicated Accounts folder in the Postman collection with a POST /api/accounts/change-password/ request
- document headers, form-data payload, success and error responses, and scripted tests for the password change flow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcb8aa86d0832ab364fb2c7d0d388e