### PR TITLE
Add documentation for authentication workflows

### DIFF
--- a/accounts/serializers/change_password_serializer.py
+++ b/accounts/serializers/change_password_serializer.py
@@ -4,11 +4,19 @@ from rest_framework import serializers
 
 
 class ChangePasswordSerializer(serializers.Serializer):
+    """Serializer that validates password change payloads for authenticated users.
+
+    The serializer expects the caller to provide the current password alongside
+    the desired new password (and its confirmation). It also leverages Django's
+    built-in password validators to enforce complexity policies.
+    """
     old_password = serializers.CharField(write_only=True)
     new_password = serializers.CharField(write_only=True)
     confirm_new_password = serializers.CharField(write_only=True)
 
+    # Perform cross-field validation to ensure the new password is acceptable.
     def validate(self, attrs):
+        """Validate that the new password is confirmed and meets policy requirements."""
         old_password = attrs.get("old_password")
         new_password = attrs.get("new_password")
         confirm_new_password = attrs.get("confirm_new_password")

--- a/accounts/serializers/login_serializer.py
+++ b/accounts/serializers/login_serializer.py
@@ -2,13 +2,18 @@ from rest_framework import serializers
 
 
 class LoginSerializer(serializers.Serializer):
-    """
-    Validate login credentials (username and password).
+    """Serializer responsible for validating basic login credentials.
+
+    The serializer only accepts the ``username`` and ``password`` fields and
+    ensures both values are supplied before the authentication service attempts
+    to verify the user.
     """
     username = serializers.CharField(required=True)
     password = serializers.CharField(required=True, write_only=True)
 
+    # Ensure both username and password values are present before proceeding.
     def validate(self, attrs):
+        """Check that both authentication fields are provided in the payload."""
         username = attrs.get("username")
         password = attrs.get("password")
 

--- a/accounts/services/auth_service.py
+++ b/accounts/services/auth_service.py
@@ -7,8 +7,19 @@ from unischedule.core.error_codes import ErrorCodes
 
 
 def login_user(data: dict) -> dict:
-    """
-    Authenticate user and return token if successful.
+    """Authenticate a user and return an API token payload.
+
+    Args:
+        data: Raw credential payload expected to contain ``username`` and
+            ``password`` fields provided by the request body.
+
+    Returns:
+        dict: A dictionary containing the issued token and a subset of the
+            user's profile information that should be returned to the client.
+
+    Raises:
+        CustomValidationError: Raised when serializer validation fails or when
+            the provided credentials do not match any active user.
     """
     # Validate input using LoginSerializer
     serializer = LoginSerializer(data=data)
@@ -52,8 +63,14 @@ def login_user(data: dict) -> dict:
 
 
 def logout_user(user) -> None:
-    """
-    Delete the user's auth token (logout).
+    """Invalidate an authenticated user's session token.
+
+    Args:
+        user: The authenticated ``User`` instance whose token must be removed.
+
+    Raises:
+        CustomValidationError: Raised when the user does not currently possess
+            a token, indicating that the logout request is invalid.
     """
     token = get_token_by_user(user)
     if not token:
@@ -68,7 +85,18 @@ def logout_user(user) -> None:
 
 
 def change_user_password(user, data: dict) -> None:
-    """Validate and change the authenticated user's password."""
+    """Validate and update the authenticated user's password.
+
+    Args:
+        user: The authenticated ``User`` instance requesting the change.
+        data: Request payload containing the current password and the desired
+            new password information.
+
+    Raises:
+        CustomValidationError: Raised when any validation step fails, including
+            serializer validation, incorrect current password, or policy
+            violations enforced by Django's password validators.
+    """
     serializer = ChangePasswordSerializer(data=data, context={"user": user})
     if not serializer.is_valid():
         raise CustomValidationError(

--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -8,7 +8,10 @@ from unischedule.core.success_codes import SuccessCodes
 
 
 class ChangePasswordAPITestCase(TestCase):
+    """End-to-end tests for the change-password API endpoint."""
+
     def setUp(self):
+        # Create and authenticate a baseline user for each test scenario.
         self.client = APIClient()
         self.user = get_user_model().objects.create_user(
             username="testuser",
@@ -19,6 +22,7 @@ class ChangePasswordAPITestCase(TestCase):
         self.client.force_authenticate(user=self.user)
 
     def test_change_password_success(self):
+        """Passwords should update when the payload is valid."""
         payload = {
             "old_password": "OldPassword123",
             "new_password": "NewPassword123!",
@@ -36,6 +40,7 @@ class ChangePasswordAPITestCase(TestCase):
         self.assertTrue(self.user.check_password(payload["new_password"]))
 
     def test_change_password_incorrect_current_password(self):
+        """Reject requests when the provided current password is incorrect."""
         payload = {
             "old_password": "WrongPassword",
             "new_password": "AnotherPassword123",
@@ -50,6 +55,7 @@ class ChangePasswordAPITestCase(TestCase):
         self.assertEqual(response.data["message"], ErrorCodes.PASSWORD_INCORRECT["message"])
 
     def test_change_password_mismatch(self):
+        """Ensure validation catches mismatched new password confirmation."""
         payload = {
             "old_password": "OldPassword123",
             "new_password": "NewPassword123",
@@ -64,6 +70,7 @@ class ChangePasswordAPITestCase(TestCase):
         self.assertIn("confirm_new_password", response.data["errors"])
 
     def test_change_password_same_as_old(self):
+        """Block requests that attempt to reuse the existing password."""
         payload = {
             "old_password": "OldPassword123",
             "new_password": "OldPassword123",
@@ -77,6 +84,7 @@ class ChangePasswordAPITestCase(TestCase):
         self.assertIn("new_password", response.data["errors"])
 
     def test_change_password_does_not_meet_policy(self):
+        """Validate that Django's password policy errors bubble up to the response."""
         payload = {
             "old_password": "OldPassword123",
             "new_password": "short",

--- a/accounts/views/auth_view.py
+++ b/accounts/views/auth_view.py
@@ -10,6 +10,7 @@ from unischedule.core.error_codes import ErrorCodes
 from unischedule.core.exceptions import CustomValidationError
 
 
+# Handle POST login requests from unauthenticated clients.
 @api_view(["POST"])
 @permission_classes([AllowAny])
 def login_view(request):
@@ -17,6 +18,7 @@ def login_view(request):
     POST - Authenticate a user using username and password. Returns token if successful.
     """
     try:
+        # Authenticate credentials via the service layer and package the success response.
         result = login_user(request.data)
         return BaseResponse.success(
             message=SuccessCodes.LOGIN_SUCCESS["message"],
@@ -25,6 +27,7 @@ def login_view(request):
             status_code=status.HTTP_200_OK
         )
     except CustomValidationError as e:
+        # Surface validation errors so the client knows why authentication failed.
         return BaseResponse.error(
             message=e.detail["message"],
             code=e.detail["code"],
@@ -33,6 +36,7 @@ def login_view(request):
             data=e.detail["data"]
         )
     except Exception:
+        # Provide a generic failure response for unexpected issues during login.
         return BaseResponse.error(
             message=ErrorCodes.LOGIN_FAILED["message"],
             code=ErrorCodes.LOGIN_FAILED["code"],
@@ -41,6 +45,7 @@ def login_view(request):
         )
 
 
+# Handle POST logout requests for authenticated users.
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def logout_view(request):
@@ -48,6 +53,7 @@ def logout_view(request):
     POST - Logout the authenticated user by deleting their auth token.
     """
     try:
+        # Remove the user's token to invalidate the current session.
         logout_user(request.user)
         return BaseResponse.success(
             message=SuccessCodes.LOGOUT_SUCCESS["message"],
@@ -56,6 +62,7 @@ def logout_view(request):
             status_code=status.HTTP_200_OK
         )
     except CustomValidationError as e:
+        # Return token related errors when the logout request is not valid.
         return BaseResponse.error(
             message=e.detail["message"],
             code=e.detail["code"],
@@ -64,6 +71,7 @@ def logout_view(request):
             data=e.detail["data"]
         )
     except Exception:
+        # Catch-all for unexpected failures when attempting to logout.
         return BaseResponse.error(
             message=ErrorCodes.LOGOUT_FAILED["message"],
             code=ErrorCodes.LOGOUT_FAILED["code"],
@@ -72,11 +80,13 @@ def logout_view(request):
         )
 
 
+# Handle POST password change requests for authenticated users.
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def change_password_view(request):
     """POST - Change the authenticated user's password."""
     try:
+        # Delegate complex password validation and update logic to the service layer.
         change_user_password(request.user, request.data)
         return BaseResponse.success(
             message=SuccessCodes.PASSWORD_CHANGE_SUCCESS["message"],
@@ -85,6 +95,7 @@ def change_password_view(request):
             status_code=status.HTTP_200_OK
         )
     except CustomValidationError as e:
+        # Relay serializer or password validation errors back to the caller.
         return BaseResponse.error(
             message=e.detail["message"],
             code=e.detail["code"],
@@ -93,6 +104,7 @@ def change_password_view(request):
             data=e.detail["data"]
         )
     except Exception:
+        # Respond with a generic failure message for any unexpected exceptions.
         return BaseResponse.error(
             message=ErrorCodes.PASSWORD_CHANGE_FAILED["message"],
             code=ErrorCodes.PASSWORD_CHANGE_FAILED["code"],


### PR DESCRIPTION
## Summary
- expand docstrings in the authentication service to clarify inputs, outputs, and error cases
- document the login and change-password serializers and annotate their validation logic
- add inline comments and descriptive docstrings to authentication views and tests to outline the request/response flow

## Testing
- python manage.py test accounts

------
https://chatgpt.com/codex/tasks/task_e_68dccb0c93fc832ab173ac51637aa06e