### PR TITLE
Document course-related services, serializers, and views

### DIFF
--- a/courses/serializers/course_serializer.py
+++ b/courses/serializers/course_serializer.py
@@ -3,8 +3,11 @@ from courses.models import Course
 
 
 class CourseSerializer(serializers.ModelSerializer):
-    """
-    Serializer for returning course data in API responses.
+    """Read-only serializer exposing the persisted attributes of a course.
+
+    No computed or derived fields are defined; each attribute maps directly to
+    a column on :class:`courses.models.Course` so the consumer receives the
+    exact database values.
     """
 
     class Meta:
@@ -22,8 +25,11 @@ class CourseSerializer(serializers.ModelSerializer):
 
 
 class CreateCourseSerializer(serializers.ModelSerializer):
-    """
-    Serializer for creating a new course.
+    """Input serializer for course creation requests.
+
+    All fields correspond to model attributes and are validated in place. The
+    serializer does not inject computed data; instead, the service layer assigns
+    the owning institution before persisting the model.
     """
 
     class Meta:
@@ -49,8 +55,11 @@ class CreateCourseSerializer(serializers.ModelSerializer):
 
 
 class UpdateCourseSerializer(serializers.ModelSerializer):
-    """
-    Serializer for updating an existing course.
+    """Serializer for partial updates on existing course records.
+
+    Every exposed field maps directly to the model; no computed values are
+    produced. ``extra_kwargs`` relaxes required flags so callers can send only
+    the fields they intend to modify.
     """
 
     class Meta:

--- a/courses/services/course_service.py
+++ b/courses/services/course_service.py
@@ -10,8 +10,12 @@ from courses.models import Course
 
 
 def create_course(data: dict, institution) -> dict:
-    """
-    Create a new course for a specific institution.
+    """Create a course for the given institution after validation.
+
+    The payload is validated with :class:`CreateCourseSerializer`. Any
+    validation failure raises :class:`CustomValidationError` populated with the
+    ``VALIDATION_FAILED`` error code so the view can return a structured HTTP
+    400 response.
     """
     serializer = CreateCourseSerializer(data=data)
     if not serializer.is_valid():
@@ -30,8 +34,11 @@ def create_course(data: dict, institution) -> dict:
 
 
 def update_course(course: Course, data: dict) -> dict:
-    """
-    Update an existing course instance.
+    """Apply partial updates to a course and return the serialized payload.
+
+    The input is validated by :class:`UpdateCourseSerializer`; on error a
+    :class:`CustomValidationError` with the ``VALIDATION_FAILED`` metadata is
+    raised so the caller can surface field-level issues.
     """
     serializer = UpdateCourseSerializer(instance=course, data=data, partial=True)
     if not serializer.is_valid():
@@ -47,8 +54,11 @@ def update_course(course: Course, data: dict) -> dict:
 
 
 def get_course_instance_or_404(course_id: int, institution) -> Course:
-    """
-    Return course instance if found, else raise 404 validation error.
+    """Return a course instance or raise a not-found error.
+
+    If the course does not exist for the provided institution a
+    :class:`CustomValidationError` configured with ``COURSE_NOT_FOUND`` is
+    raised, mimicking the semantics of ``Http404`` in API responses.
     """
     course = course_repository.get_course_by_id_and_institution(course_id, institution)
     if not course:
@@ -62,23 +72,29 @@ def get_course_instance_or_404(course_id: int, institution) -> Course:
 
 
 def get_course_by_id_or_404(course_id: int, institution) -> dict:
-    """
-    Return serialized course if found.
+    """Return serialized course data or propagate the not-found error.
+
+    Delegates to :func:`get_course_instance_or_404` and therefore raises the
+    same :class:`CustomValidationError` when the course is missing.
     """
     course = get_course_instance_or_404(course_id, institution)
     return CourseSerializer(course).data
 
 
 def delete_course(course: Course) -> None:
-    """
-    Soft delete a course by marking it as deleted.
+    """Soft-delete the supplied course by delegating to the repository.
+
+    This function currently relies on the repository layer for error handling
+    and therefore will bubble up any unexpected exceptions to the caller.
     """
     course_repository.soft_delete_course(course)
 
 
 def list_courses(institution) -> list[dict]:
-    """
-    Return serialized list of all courses for the given institution.
+    """Return serialized courses for the institution.
+
+    The repository lookup is expected to succeed; any lower-level exceptions
+    (e.g., database errors) are propagated for the caller to handle.
     """
     queryset = course_repository.list_courses_by_institution(institution)
     return CourseSerializer(queryset, many=True).data

--- a/courses/views/course_view.py
+++ b/courses/views/course_view.py
@@ -17,9 +17,12 @@ def list_courses_view(request):
     """
     GET - List all courses for the authenticated user's institution.
     """
+    # Parse input context (authenticated institution)
     institution = request.user.institution
+    # Delegate to the service layer to fetch serialized courses
     courses = course_service.list_courses(institution)
 
+    # Build the HTTP response payload
     return BaseResponse.success(
         message=SuccessCodes.COURSE_LISTED["message"],
         code=SuccessCodes.COURSE_LISTED["code"],
@@ -33,9 +36,12 @@ def retrieve_course_view(request, course_id):
     """
     GET - Retrieve a course by ID.
     """
+    # Parse input context (institution and resource identifier)
     institution = request.user.institution
+    # Ask the service layer for the requested course
     course = course_service.get_course_by_id_or_404(course_id, institution)
 
+    # Build the HTTP response payload
     return BaseResponse.success(
         message=SuccessCodes.COURSE_RETRIEVED["message"],
         code=SuccessCodes.COURSE_RETRIEVED["code"],
@@ -49,11 +55,14 @@ def create_course_view(request):
     """
     POST - Create a new course.
     """
+    # Parse incoming data and contextual institution
     institution = request.user.institution
     data = request.data
 
     try:
+        # Delegate creation to the service layer
         course = course_service.create_course(data, institution)
+        # Build success response with created resource
         return BaseResponse.success(
             message=SuccessCodes.COURSE_CREATED["message"],
             code=SuccessCodes.COURSE_CREATED["code"],
@@ -93,11 +102,14 @@ def update_course_view(request, course_id):
     """
     PUT - Update an existing course.
     """
+    # Parse target institution and existing course instance
     institution = request.user.institution
     course = course_service.get_course_instance_or_404(course_id, institution)
 
     try:
+        # Delegate update to the service layer with request data
         updated_course = course_service.update_course(course, request.data)
+        # Build success response with updated payload
         return BaseResponse.success(
             message=SuccessCodes.COURSE_UPDATED["message"],
             code=SuccessCodes.COURSE_UPDATED["code"],
@@ -136,11 +148,14 @@ def delete_course_view(request, course_id):
     """
     DELETE - Soft delete a course.
     """
+    # Parse the request context and load the target course
     institution = request.user.institution
     course = course_service.get_course_instance_or_404(course_id, institution)
 
     try:
+        # Delegate deletion to the service layer
         course_service.delete_course(course)
+        # Build success response indicating removal
         return BaseResponse.success(
             message=SuccessCodes.COURSE_DELETED["message"],
             code=SuccessCodes.COURSE_DELETED["code"]


### PR DESCRIPTION
## Summary
- expand course service docstrings to cover behaviour and propagated errors
- add detailed class docstrings to course serializers describing their fields
- annotate course views with inline comments explaining request handling steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd960d298832abd6571b0c6f679ba