### PR TITLE
Document professor module components

### DIFF
--- a/professors/serializers/professor_serializer.py
+++ b/professors/serializers/professor_serializer.py
@@ -5,6 +5,14 @@ from professors.models import Professor
 class ProfessorSerializer(serializers.ModelSerializer):
     """
     Serializer for representing professor data in API responses.
+
+    Fields:
+        id: Database identifier exposed to clients.
+        first_name: Professor's given name.
+        last_name: Professor's family name.
+        national_code: National identification number used for uniqueness.
+        phone_number: Contact phone for the professor.
+        institution: Foreign key reference to the owning institution.
     """
     class Meta:
         model = Professor
@@ -21,6 +29,11 @@ class ProfessorSerializer(serializers.ModelSerializer):
 class CreateProfessorSerializer(serializers.ModelSerializer):
     """
     Serializer for creating a new professor.
+
+    Fields:
+        first_name, last_name: Personal information required to register the professor.
+        national_code: Must be unique per institution and exactly 10 digits.
+        phone_number: Optional contact number captured at creation time.
     """
 
     class Meta:
@@ -33,6 +46,7 @@ class CreateProfessorSerializer(serializers.ModelSerializer):
         ]
 
     def validate_national_code(self, value):
+        """Ensure the national code has the correct format and is unique per institution."""
         if not value.isdigit() or len(value) != 10:
             raise serializers.ValidationError("کد ملی باید ۱۰ رقم و فقط عدد باشد.")
 
@@ -50,6 +64,10 @@ class CreateProfessorSerializer(serializers.ModelSerializer):
 class UpdateProfessorSerializer(serializers.ModelSerializer):
     """
     Serializer for updating professor details.
+
+    Fields:
+        first_name, last_name, phone_number: All optional to support partial updates
+        while other immutable fields (national_code, institution) remain unchanged.
     """
 
     class Meta:

--- a/professors/tests/test_professor_creation.py
+++ b/professors/tests/test_professor_creation.py
@@ -26,5 +26,7 @@ class ProfessorCreationTests(TestCase):
         first_response = self.client.post(self.url, self.professor_data, format="json")
         self.assertEqual(first_response.status_code, status.HTTP_201_CREATED)
 
+        # Attempting to create the same professor again verifies the API's
+        # protection against duplicate national codes.
         second_response = self.client.post(self.url, self.professor_data, format="json")
         self.assertEqual(second_response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/professors/views/professor_view.py
+++ b/professors/views/professor_view.py
@@ -22,6 +22,8 @@ def list_professors_view(request):
     institution = request.user.institution
     professors = professor_service.list_professors(institution)
 
+    # BaseResponse.success ensures every success response shares the same
+    # envelope (message, code, data) used across the project.
     return BaseResponse.success(
         message=SuccessCodes.PROFESSOR_LISTED["message"],
         code=SuccessCodes.PROFESSOR_LISTED["code"],
@@ -35,6 +37,8 @@ def retrieve_professor_view(request, professor_id):
     institution = request.user.institution
     serialized_professor = professor_service.get_professor_by_id_or_404(professor_id, institution)
 
+    # Successful retrievals are wrapped in the common response format so
+    # clients can parse status metadata consistently.
     return BaseResponse.success(
         message=SuccessCodes.PROFESSOR_RETRIEVED["message"],
         code=SuccessCodes.PROFESSOR_RETRIEVED["code"],
@@ -61,6 +65,8 @@ def create_professor_view(request):
         )
 
     except CustomValidationError as e:
+        # Validation errors also leverage BaseResponse.error so error payloads
+        # remain predictable for API consumers.
         return BaseResponse.error(
             message=e.detail["message"],
             code=e.detail["code"],
@@ -71,6 +77,8 @@ def create_professor_view(request):
 
 
     except Exception:
+        # Unexpected errors fall back to a predefined error code while still
+        # returning the structured error response.
         return BaseResponse.error(
             message=ErrorCodes.PROFESSOR_CREATION_FAILED["message"],
             code=ErrorCodes.PROFESSOR_CREATION_FAILED["code"],
@@ -97,6 +105,8 @@ def update_professor_view(request, professor_id):
         )
 
     except CustomValidationError as e:
+        # Translate domain-specific validation issues to the standard error
+        # schema to keep client handling consistent.
         return BaseResponse.error(
             message=e.detail["message"],
             code=e.detail["code"],
@@ -106,6 +116,7 @@ def update_professor_view(request, professor_id):
         )
 
     except ValidationError as e:
+        # DRF validation exceptions are also normalized via BaseResponse.
         return BaseResponse.error(
             message=ErrorCodes.VALIDATION_FAILED["message"],
             code=ErrorCodes.VALIDATION_FAILED["code"],
@@ -115,6 +126,7 @@ def update_professor_view(request, professor_id):
 
     except Exception:
         logger.exception("Unhandled exception while updating professor")
+        # Even unexpected errors are wrapped in the same response contract.
         return BaseResponse.error(
             message=ErrorCodes.PROFESSOR_UPDATE_FAILED["message"],
             code=ErrorCodes.PROFESSOR_UPDATE_FAILED["code"],
@@ -140,6 +152,8 @@ def delete_professor_view(request, professor_id):
         )
     except Exception:
         logger.exception("Unhandled exception while deleting professor")
+        # Soft-delete failures are still presented through the BaseResponse
+        # abstraction for a uniform API.
         return BaseResponse.error(
             message=ErrorCodes.PROFESSOR_DELETION_FAILED["message"],
             code=ErrorCodes.PROFESSOR_DELETION_FAILED["code"],


### PR DESCRIPTION
## Summary
- expand CRUD service docstrings and clarify duplicate national code handling
- document professor serializers including field descriptions and validator purpose
- describe standardized API response handling in professor views and annotate test coverage rationale

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcdb7d9d1c832a9b888616217b08dc