### PR TITLE
Document semester workflows and add activation tests

### DIFF
--- a/semesters/repositories/semester_repository.py
+++ b/semesters/repositories/semester_repository.py
@@ -6,6 +6,7 @@ def get_all_semesters_by_institution(institution):
     """
     Retrieve all semesters (not deleted) for a given institution, ordered by start date.
     """
+    # Filter keeps only non-deleted semesters for the institution ordered by start date.
     return Semester.objects.filter(institution=institution, is_deleted=False).order_by("-start_date")
 
 
@@ -13,6 +14,7 @@ def get_semester_by_id_and_institution(semester_id, institution):
     """
     Retrieve a specific semester by ID and institution.
     """
+    # Query narrows down by id and institution while ignoring soft-deleted rows.
     return Semester.objects.filter(id=semester_id, institution=institution, is_deleted=False).first()
 
 
@@ -20,6 +22,7 @@ def get_active_semester(institution):
     """
     Return the currently active semester for a specific institution.
     """
+    # Find the single active semester for the institution (returns ``None`` if absent).
     return Semester.objects.filter(institution=institution, is_active=True, is_deleted=False).first()
 
 
@@ -53,4 +56,5 @@ def deactivate_all_semesters(institution):
     """
     Deactivate all semesters of a given institution.
     """
+    # Bulk update clears the active flag on every semester that belongs to the institution.
     Semester.objects.filter(institution=institution, is_deleted=False, is_active=True).update(is_active=False)

--- a/semesters/tests.py
+++ b/semesters/tests.py
@@ -1,3 +1,88 @@
+from datetime import date
+
 from django.test import TestCase
 
-# Create your tests here.
+from institutions.models import Institution
+from semesters.models import Semester
+from semesters.services import semester_service
+
+
+class SemesterServiceTests(TestCase):
+    """Integration style tests covering the public semester service helpers."""
+
+    def setUp(self):
+        """Create a reusable institution instance for each scenario."""
+        self.institution = Institution.objects.create(name="Test University", slug="test-university")
+
+    def test_create_semester_deactivates_existing_active(self):
+        """Creating an active semester should deactivate other active records."""
+
+        first_semester = Semester.objects.create(
+            institution=self.institution,
+            title="Spring 2023",
+            start_date=date(2023, 1, 1),
+            end_date=date(2023, 6, 1),
+            is_active=True,
+        )
+
+        payload = {
+            "title": "Fall 2023",
+            "start_date": date(2023, 9, 1),
+            "end_date": date(2024, 1, 1),
+            "is_active": True,
+        }
+
+        semester_service.create_semester(payload, self.institution)
+
+        first_semester.refresh_from_db()
+        self.assertFalse(first_semester.is_active, "The previously active semester should be deactivated.")
+
+    def test_update_semester_enforces_single_active(self):
+        """Updating a semester to active must turn off the other semester."""
+
+        inactive_semester = Semester.objects.create(
+            institution=self.institution,
+            title="Spring 2024",
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 6, 1),
+            is_active=False,
+        )
+        active_semester = Semester.objects.create(
+            institution=self.institution,
+            title="Summer 2024",
+            start_date=date(2024, 6, 2),
+            end_date=date(2024, 9, 1),
+            is_active=True,
+        )
+
+        semester_service.update_semester(inactive_semester, {"is_active": True})
+
+        active_semester.refresh_from_db()
+        inactive_semester.refresh_from_db()
+        self.assertTrue(inactive_semester.is_active, "The updated semester should be marked active.")
+        self.assertFalse(active_semester.is_active, "The previously active semester must be deactivated.")
+
+    def test_set_active_semester_helper(self):
+        """The explicit helper should activate the provided semester only."""
+
+        first_semester = Semester.objects.create(
+            institution=self.institution,
+            title="Winter 2024",
+            start_date=date(2024, 12, 1),
+            end_date=date(2025, 2, 28),
+            is_active=False,
+        )
+        second_semester = Semester.objects.create(
+            institution=self.institution,
+            title="Spring 2025",
+            start_date=date(2025, 3, 1),
+            end_date=date(2025, 7, 1),
+            is_active=True,
+        )
+
+        semester_service.set_active_semester(first_semester)
+
+        first_semester.refresh_from_db()
+        second_semester.refresh_from_db()
+        self.assertTrue(first_semester.is_active, "The selected semester should become active.")
+        self.assertFalse(second_semester.is_active, "All other semesters must be inactive after the change.")


### PR DESCRIPTION
## Summary
- document semester service methods with detailed side-effect descriptions
- add inline comments clarifying repository query intent
- expand API view docstrings to explain control flow and error handling
- add activation regression tests with descriptive docstrings for each scenario

## Testing
- python manage.py test semesters

------
https://chatgpt.com/codex/tasks/task_e_68dcdc4962a4832a9b06e9d5efd65382