### PR TITLE
Document class session services and tests

### DIFF
--- a/schedules/serializers/class_session_serializers.py
+++ b/schedules/serializers/class_session_serializers.py
@@ -3,6 +3,8 @@ from schedules.models import ClassSession
 
 
 class ClassSessionSerializer(serializers.ModelSerializer):
+    """سریالایزر عمومی برای نمایش جزئیات جلسهٔ کلاس."""
+
     class Meta:
         model = ClassSession
         fields = [
@@ -23,6 +25,8 @@ class ClassSessionSerializer(serializers.ModelSerializer):
 
 
 class CreateClassSessionSerializer(serializers.ModelSerializer):
+    """سریالایزر ایجاد که ساختار فیلدهای روز/هفته و اعتبارسنجی زمان را تشریح می‌کند."""
+
     class Meta:
         model = ClassSession
         fields = [
@@ -40,6 +44,9 @@ class CreateClassSessionSerializer(serializers.ModelSerializer):
         ]
 
     def validate(self, attrs):
+        """اطمینان می‌دهد زمان شروع قبل از پایان بوده و ترکیب روز/نوع هفته معتبر باشد."""
+        # day_of_week و week_type به صورت مقادیر متنی انتخابی در مدل تعریف شده‌اند و
+        # در سطح مدل توسط گزینه‌ها محدود می‌شوند؛ در اینجا تنها ترتیب زمانی بازه بررسی می‌شود.
         start = attrs.get("start_time")
         end = attrs.get("end_time")
         if start and end and start >= end:
@@ -48,6 +55,8 @@ class CreateClassSessionSerializer(serializers.ModelSerializer):
 
 
 class UpdateClassSessionSerializer(serializers.ModelSerializer):
+    """سریالایزر به‌روزرسانی که فیلدهای روز/نوع هفته را اختیاری کرده و منطق زمان را بازاستفاده می‌کند."""
+
     class Meta:
         model = ClassSession
         fields = [
@@ -66,6 +75,7 @@ class UpdateClassSessionSerializer(serializers.ModelSerializer):
         extra_kwargs = {f: {"required": False} for f in fields}
 
     def validate(self, attrs):
+        """در صورت ارسال هر دو مقدار زمان، ترتیب آن‌ها را برای جلوگیری از بازه معکوس بررسی می‌کند."""
         start = attrs.get("start_time")
         end = attrs.get("end_time")
         if start and end and start >= end:

--- a/schedules/services/class_session_service.py
+++ b/schedules/services/class_session_service.py
@@ -22,6 +22,7 @@ def _ensure_institution(institution) -> None:
 
 
 def _check_conflict(data, institution):
+    """بررسی می‌کند که زمان‌بندی کلاس با سایر جلسات در همان موسسه تداخل نداشته باشد."""
     if class_session_repository.has_time_conflict(
         institution=institution,
         semester=data["semester"],
@@ -42,6 +43,7 @@ def _check_conflict(data, institution):
 
 
 def create_class_session(data: dict, institution) -> dict:
+    """یک جلسهٔ جدید ایجاد می‌کند و قبل از ذخیره از نبود تداخل زمانی اطمینان می‌یابد."""
     _ensure_institution(institution)
     serializer = CreateClassSessionSerializer(data=data)
     if not serializer.is_valid():
@@ -52,6 +54,7 @@ def create_class_session(data: dict, institution) -> dict:
             errors=serializer.errors,
         )
     validated_data = serializer.validated_data
+    # موسسه از درخواست استخراج و به داده‌های معتبر شده افزوده می‌شود
     validated_data["institution"] = institution
     _check_conflict(validated_data, institution)
     session = class_session_repository.create_class_session(validated_data)
@@ -60,6 +63,7 @@ def create_class_session(data: dict, institution) -> dict:
 
 
 def update_class_session(session: ClassSession, data: dict) -> dict:
+    """یک جلسهٔ موجود را با داده‌های جدید به‌روزرسانی کرده و هرگونه تداخل احتمالی را بررسی می‌کند."""
     _ensure_institution(session.institution)
     serializer = UpdateClassSessionSerializer(instance=session, data=data, partial=True)
     if not serializer.is_valid():
@@ -69,6 +73,7 @@ def update_class_session(session: ClassSession, data: dict) -> dict:
             status_code=ErrorCodes.VALIDATION_FAILED["status_code"],
             errors=serializer.errors,
         )
+    # نسخهٔ اصلی برای ثبت وضعیت پیش از تغییر نگه‌داری می‌شود تا کش نمایش‌ها نیز به‌روزرسانی گردد
     original_session = ClassSession.objects.get(pk=session.pk)
     validated_data = serializer.validated_data
     validated_data["id"] = session.id

--- a/schedules/views/class_session_view.py
+++ b/schedules/views/class_session_view.py
@@ -14,9 +14,11 @@ from schedules.services import class_session_service
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def list_class_sessions_view(request):
+    """لیست جلسات کلاس را با استفاده از BaseResponse و مدیریت خطا بازمی‌گرداند."""
     institution = request.user.institution
     try:
         sessions = class_session_service.list_class_sessions(institution)
+        # BaseResponse.success خروجی استاندارد شدهٔ موفقیت را آماده می‌کند
         return BaseResponse.success(
             message=SuccessCodes.CLASS_SESSION_LISTED["message"],
             code=SuccessCodes.CLASS_SESSION_LISTED["code"],
@@ -35,6 +37,7 @@ def list_class_sessions_view(request):
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def retrieve_class_session_view(request, session_id):
+    """جزئیات جلسه را بر اساس شناسه بازمی‌گرداند و خطاها را به قالب عمومی تبدیل می‌کند."""
     institution = request.user.institution
     try:
         session = class_session_service.get_class_session_by_id_or_404(session_id, institution)
@@ -56,6 +59,7 @@ def retrieve_class_session_view(request, session_id):
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def create_class_session_view(request):
+    """جلسهٔ جدید را ایجاد کرده و انواع استثناها را به پاسخ استاندارد تبدیل می‌کند."""
     institution = request.user.institution
     try:
         session = class_session_service.create_class_session(request.data, institution)
@@ -74,6 +78,7 @@ def create_class_session_view(request):
             data=e.detail["data"],
         )
     except ValidationError as e:
+        # ValidationError داخلی DRF به خطای عمومی Validation ترجمه می‌شود تا پیام یکسان بماند
         return BaseResponse.error(
             message=ErrorCodes.VALIDATION_FAILED["message"],
             code=ErrorCodes.VALIDATION_FAILED["code"],
@@ -81,6 +86,7 @@ def create_class_session_view(request):
             errors=e.detail,
         )
     except Exception:
+        # برای خطاهای پیش‌بینی‌نشده، پیام کلی شکست ایجاد کلاس بازگردانده می‌شود
         return BaseResponse.error(
             message=ErrorCodes.CLASS_SESSION_CREATION_FAILED["message"],
             code=ErrorCodes.CLASS_SESSION_CREATION_FAILED["code"],
@@ -92,6 +98,7 @@ def create_class_session_view(request):
 @api_view(["PUT"])
 @permission_classes([IsAuthenticated])
 def update_class_session_view(request, session_id):
+    """جلسهٔ موجود را به‌روزرسانی کرده و پیام‌های خطا را در قالب BaseResponse بازمی‌گرداند."""
     institution = request.user.institution
     try:
         session = class_session_service.get_class_session_instance_or_404(session_id, institution)
@@ -110,6 +117,7 @@ def update_class_session_view(request, session_id):
             data=e.detail["data"],
         )
     except ValidationError as e:
+        # خطای اعتبارسنجی DRF با پیام عمومی خطای اعتبارسنجی بازگردانده می‌شود
         return BaseResponse.error(
             message=ErrorCodes.VALIDATION_FAILED["message"],
             code=ErrorCodes.VALIDATION_FAILED["code"],
@@ -117,6 +125,7 @@ def update_class_session_view(request, session_id):
             errors=e.detail,
         )
     except Exception:
+        # سایر خطاهای غیرمنتظره با پیام شکست به‌روزرسانی پاسخ داده می‌شوند
         return BaseResponse.error(
             message=ErrorCodes.CLASS_SESSION_UPDATE_FAILED["message"],
             code=ErrorCodes.CLASS_SESSION_UPDATE_FAILED["code"],
@@ -128,6 +137,7 @@ def update_class_session_view(request, session_id):
 @api_view(["DELETE"])
 @permission_classes([IsAuthenticated])
 def delete_class_session_view(request, session_id):
+    """جلسهٔ مشخص شده را حذف نرم می‌کند و از BaseResponse برای پاسخ موفق یا خطا بهره می‌گیرد."""
     institution = request.user.institution
     try:
         session = class_session_service.get_class_session_instance_or_404(session_id, institution)
@@ -145,6 +155,7 @@ def delete_class_session_view(request, session_id):
             data=e.detail["data"],
         )
     except Exception:
+        # آخرین سد دفاعی برای خطاهای حذف که خارج از سناریوهای انتظار هستند
         return BaseResponse.error(
             message=ErrorCodes.CLASS_SESSION_DELETION_FAILED["message"],
             code=ErrorCodes.CLASS_SESSION_DELETION_FAILED["code"],


### PR DESCRIPTION
## Summary
- add docstrings and inline comments to class session service functions highlighting conflict handling
- document serializer fields and validation for class session scheduling
- expand view and test modules with comments describing BaseResponse usage and conflict scenarios

## Testing
- not run (documentation updates only)

------
https://chatgpt.com/codex/tasks/task_e_68dcdded13b0832aa2d977223ee86263