### PR TITLE
docs: document core helper modules

### DIFF
--- a/unischedule/core/error_codes.py
+++ b/unischedule/core/error_codes.py
@@ -1,8 +1,23 @@
+"""Central repository of error codes referenced by API responses.
+
+Error codes use the ``4XYZ`` family so they are easy to distinguish from
+success codes. The second digit hints at the domain: ``9`` for institutions,
+``1`` for semesters, etc. This convention keeps HTTP codes, logical codes and
+user-facing messages together, which simplifies raising errors through
+``BaseResponse.error`` or :class:`~unischedule.core.exceptions.CustomValidationError`.
+
+Example:
+    ``BaseResponse.error(**ErrorCodes.SEMESTER_NOT_FOUND)`` immediately returns
+    an HTTP 404 without redefining the message or application code.
+"""
+
 from rest_framework import status
 
 
 class ErrorCodes:
-    # Generic
+    """Domain grouped error payloads shared across serializers and services."""
+
+    # Generic: 40xx codes cover validation and permission scenarios.
     VALIDATION_FAILED = {
         "code": "4000",
         "message": "اطلاعات وارد شده نامعتبر است.",
@@ -18,7 +33,7 @@ class ErrorCodes:
         "data": {},
     }
 
-    # Institution
+    # Institution: 49xx codes represent issues when managing institutions.
     INSTITUTION_NOT_FOUND = {
         "code": "4900",
         "message": "مؤسسه مورد نظر یافت نشد.",
@@ -55,7 +70,7 @@ class ErrorCodes:
         "data": {},
     }
 
-    # Semester
+    # Semester: 41xx warnings communicate failures on academic terms.
     SEMESTER_NOT_FOUND = {
         "code": "4100",
         "message": "ترم مورد نظر یافت نشد.",
@@ -92,7 +107,7 @@ class ErrorCodes:
         "data": {},
     }
 
-    # Professor
+    # Professor: 42xx handles CRUD exceptions around faculty members.
     PROFESSOR_NOT_FOUND = {
         "code": "4200",
         "message": "استاد مورد نظر یافت نشد.",
@@ -122,7 +137,7 @@ class ErrorCodes:
         "data": {},
     }
 
-    # Course
+    # Course: 43xx focuses on catalog validation and persistence issues.
     COURSE_CREATION_FAILED = {
         "code": "4301",
         "message": "ایجاد درس با خطا مواجه شد.",
@@ -159,7 +174,7 @@ class ErrorCodes:
         "data": {},
     }
 
-    # Building
+    # Building: 44xx is reserved for facility management failures.
     BUILDING_NOT_FOUND = {
         "code": "4400",
         "message": "ساختمان مورد نظر یافت نشد.",
@@ -189,7 +204,7 @@ class ErrorCodes:
         "data": {},
     }
 
-    # Classroom
+    # Classroom: 45xx highlights classroom lifecycle problems.
     CLASSROOM_NOT_FOUND = {
         "code": "4500",
         "message": "کلاس مورد نظر یافت نشد.",
@@ -219,7 +234,7 @@ class ErrorCodes:
         "data": {},
     }
 
-    # Class Session
+    # Class Session: 46xx represents scheduling conflicts or errors.
     CLASS_SESSION_NOT_FOUND = {
         "code": "4600",
         "message": "جلسه کلاس مورد نظر یافت نشد.",
@@ -256,7 +271,7 @@ class ErrorCodes:
         "data": {},
     }
 
-    # Display screens
+    # Display screens: 48xx is dedicated to signage endpoints.
     DISPLAY_SCREEN_NOT_FOUND = {
         "code": "4800",
         "message": "صفحه نمایش مورد نظر یافت نشد.",
@@ -286,7 +301,7 @@ class ErrorCodes:
         "data": {},
     }
 
-    # Auth
+    # Auth: 47xx concentrates on authentication and security workflows.
     INVALID_CREDENTIALS = {
         "code": "4700",
         "message": "نام کاربری یا رمز عبور اشتباه است.",

--- a/unischedule/core/exceptions.py
+++ b/unischedule/core/exceptions.py
@@ -1,13 +1,18 @@
+"""Exception helpers that integrate domain errors with DRF's machinery.
+
+The module centralises a single custom exception to standardise how service
+layer validations bubble up to API responses. It mirrors the payload format
+produced by :class:`unischedule.core.base_response.BaseResponse` so clients see
+consistent structures whether the error was raised manually or via helper
+functions.
+"""
+
 from rest_framework.exceptions import APIException
 from rest_framework import status
 
 
 class CustomValidationError(APIException):
-    """
-    Custom exception for handling logical or validation-related errors in service layer.
-
-    This is used in cases like "OTP not expired", "duplicate semester", etc., and fully integrates with DRF's exception system.
-    """
+    """Raise domain-specific validation errors that follow the API contract."""
 
     def __init__(
         self,
@@ -17,13 +22,14 @@ class CustomValidationError(APIException):
         status_code=status.HTTP_400_BAD_REQUEST,
         data=None
     ):
-        """
+        """Initialise the exception with API-friendly fields.
+
         Args:
-            message (str): Main error message for client
-            code (int or str): Logical error code used in API (e.g., "3001")
-            errors (list or dict): Validation errors or extra error info
-            status_code (int): HTTP status code (e.g., 400, 403)
-            data (dict): Optional additional data to return to the client
+            message (str): Main error message for client.
+            code (int | str): Logical error code used in API (e.g., ``"3001"``).
+            errors (list | dict): Validation errors or extra error info.
+            status_code (int): HTTP status code (e.g., 400, 403).
+            data (dict): Optional additional data to return to the client.
         """
         self.status_code = status_code
         self.detail = {

--- a/unischedule/core/success_codes.py
+++ b/unischedule/core/success_codes.py
@@ -1,5 +1,21 @@
+"""Shared application success codes grouped by domain.
+
+The codes follow a ``2XYZ`` convention where the second digit indicates the
+domain (e.g. ``8`` for institutions, ``1`` for semesters). Grouping the codes
+here helps product and client teams maintain a single source of truth when
+mapping server responses to UI messages.
+
+Example:
+    ``BaseResponse.success(**SuccessCodes.INSTITUTION_CREATED)`` turns the
+    constant into the standard response format without duplicating the message
+    at the call site.
+"""
+
+
 class SuccessCodes:
-    # Institutions
+    """Namespace containing grouped dictionaries used by ``BaseResponse``."""
+
+    # Institutions: all institution management scenarios share the 28xx range.
     INSTITUTION_LISTED = {
         "code": "2800",
         "message": "لیست مؤسسات با موفقیت دریافت شد.",
@@ -26,7 +42,7 @@ class SuccessCodes:
         "data": {},
     }
 
-    # Semesters
+    # Semesters: the 21xx series communicates academic term lifecycle events.
     SEMESTER_CREATED = {
         "code": "2100",
         "message": "ترم با موفقیت ایجاد شد.",
@@ -56,7 +72,8 @@ class SuccessCodes:
         "message": "ترم فعال با موفقیت تنظیم شد.",
         "data": {}
     }
-    # Professors
+
+    # Professors: 22xx codes mirror CRUD operations on faculty profiles.
     PROFESSOR_LISTED = {
         "code": "2201",
         "message": "لیست اساتید با موفقیت دریافت شد.",
@@ -87,7 +104,7 @@ class SuccessCodes:
         "data": {}
     }
 
-    # === COURSE ===
+    # Courses: 23xx indicates catalog level changes and queries.
     COURSE_CREATED = {
         "code": "2301",
         "message": "درس جدید با موفقیت ایجاد شد.",
@@ -118,7 +135,7 @@ class SuccessCodes:
         "data": {}
     }
 
-    # Buildings
+    # Buildings: facility management uses 24xx aligned with location entities.
     BUILDING_CREATED = {
         "code": "2401",
         "message": "ساختمان با موفقیت ایجاد شد."
@@ -139,7 +156,8 @@ class SuccessCodes:
         "code": "2405",
         "message": "لیست ساختمان‌ها با موفقیت دریافت شد."
     }
-    # --------- Classroom Success Codes ---------
+
+    # Classrooms: 25xx signals updates to physical classroom resources.
     CLASSROOM_LISTED = {
         "code": "2501",
         "message": "لیست کلاس‌ها با موفقیت دریافت شد."
@@ -164,7 +182,8 @@ class SuccessCodes:
         "code": "2505",
         "message": "کلاس با موفقیت حذف شد."
     }
-    # Class Sessions
+
+    # Class Sessions: 26xx maps to scheduling occurrences inside semesters.
     CLASS_SESSION_CREATED = {
         "code": "2601",
         "message": "جلسه کلاس با موفقیت ایجاد شد.",
@@ -190,7 +209,8 @@ class SuccessCodes:
         "message": "جلسه کلاس با موفقیت حذف شد.",
         "data": {},
     }
-    # Display screens
+
+    # Display screens: 27xx is dedicated to digital signage endpoints.
     DISPLAY_SCREEN_CREATED = {
         "code": "2701",
         "message": "صفحه نمایش با موفقیت ایجاد شد.",
@@ -221,7 +241,8 @@ class SuccessCodes:
         "message": "اطلاعات صفحه نمایش با موفقیت بارگذاری شد.",
         "data": {},
     }
-    # ✅ Auth
+
+    # ✅ Auth: success codes used by authentication flows.
     LOGIN_SUCCESS = {
         "code": 2001,
         "message": "ورود با موفقیت انجام شد.",


### PR DESCRIPTION
## Summary
- add module-level docstrings describing the shared base model and response utilities
- explain the grouping philosophy for success and error code constants with example usage
- document the custom API exception helper to align with the shared response schema

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dce00b6e8c832aa60f50734d1b74a7