### PR TITLE
Add documentation around display admin, cache, and public routes

### DIFF
--- a/displays/__init__.py
+++ b/displays/__init__.py
@@ -1,0 +1,8 @@
+"""Display management app for public-facing schedule screens.
+
+This Django app exposes the administrative APIs, background services, and
+public endpoints that power digital signage screens.  It allows institution
+staff to curate which sessions appear on each screen while publishing a
+cacheable JSON feed that kiosks and TVs can poll without authentication.
+"""
+

--- a/displays/admin.py
+++ b/displays/admin.py
@@ -9,6 +9,8 @@ from displays.models import DisplayScreen
 
 @admin.register(DisplayScreen)
 class DisplayScreenAdmin(admin.ModelAdmin):
+    # Display columns emphasise ownership, publication state, and quick access
+    # to the public preview URL so operators can verify the feed at a glance.
     list_display = (
         "title",
         "institution",
@@ -23,6 +25,8 @@ class DisplayScreenAdmin(admin.ModelAdmin):
     search_fields = ("title", "slug", "institution__name")
     readonly_fields = ("slug", "access_token", "created_at", "updated_at", "preview_link")
     autocomplete_fields = ("institution",)
+    # Provide a one-click action that opens the unauthenticated JSON preview
+    # used by kiosk devices.  Limited to single selection to avoid ambiguity.
     actions = ["preview_screen"]
     fieldsets = (
         (None, {
@@ -78,6 +82,8 @@ class DisplayScreenAdmin(admin.ModelAdmin):
 
     @admin.action(description="باز کردن JSON عمومی")
     def preview_screen(self, request, queryset):
+        # Ensure that staff explicitly choose a single screen before
+        # redirecting them to the external preview endpoint.
         if queryset.count() != 1:
             self.message_user(
                 request,

--- a/displays/services/display_service.py
+++ b/displays/services/display_service.py
@@ -240,6 +240,8 @@ def build_public_payload(screen: DisplayScreen, *, use_cache: bool = True) -> di
     computed filter metadata.  Newly generated payloads are stored in the cache
     for the screen ``refresh_interval``.
     """
+    # Cache keys are namespaced with the ``display:`` prefix so they do not
+    # collide with other app caches; the slug uniquely identifies each screen.
     cache_key = f"display:{screen.slug}"
     if use_cache:
         cached = cache.get(cache_key)
@@ -264,4 +266,6 @@ def build_public_payload(screen: DisplayScreen, *, use_cache: bool = True) -> di
 
 def invalidate_screen_cache(screen: DisplayScreen) -> None:
     """Remove the cached payload for the provided screen."""
+    # Mirrors the naming strategy in ``build_public_payload`` to target only the
+    # affected screen without disturbing other cached responses.
     cache.delete(f"display:{screen.slug}")

--- a/displays/urls.py
+++ b/displays/urls.py
@@ -19,6 +19,9 @@ api_urlpatterns = [
     path("screens/<int:screen_id>/delete/", delete_display_screen_view, name="delete-screen"),
 ]
 
+# Public preview endpoints are intentionally unauthenticated; they are consumed
+# by kiosk/TV clients that only know the screen slug.  Access should be limited
+# to opaque slugs shared with trusted devices.
 public_urlpatterns = [
     path("<slug:slug>/", public_display_view, name="public-display"),
 ]


### PR DESCRIPTION
## Summary
- document the display app entry module to describe its responsibilities
- clarify admin list columns, actions, and cache key naming with inline comments
- explain the intent and access pattern for the public preview route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dce153915c832ab81ed79cc2f58ac1