### PR TITLE
Fix filter activation validation and add regression tests

### DIFF
--- a/displays/serializers/display_serializers.py
+++ b/displays/serializers/display_serializers.py
@@ -190,7 +190,8 @@ class DisplayScreenWriteSerializer(serializers.ModelSerializer):
         if duration is serializers.empty and instance is None:
             attrs.setdefault("filter_duration_seconds", 0)
 
-        if "filter_is_active" in attrs:
+        filter_is_active_provided = "filter_is_active" in attrs
+        if filter_is_active_provided:
             provided_is_active = attrs.get("filter_is_active")
             attrs["filter_is_active"] = bool(provided_is_active)
             filter_is_active = bool(provided_is_active)
@@ -233,6 +234,10 @@ class DisplayScreenWriteSerializer(serializers.ModelSerializer):
 
         if not has_selector:
             if filter_is_active:
+                if filter_is_active_provided:
+                    raise serializers.ValidationError(
+                        "حداقل یکی از معیارهای فیلتر باید مشخص شود."
+                    )
                 attrs["filter_is_active"] = False
                 filter_is_active = False
             else:


### PR DESCRIPTION
## Summary
- prevent the serializer from silently disabling filters when the client explicitly requests activation without selectors
- keep automatic disabling behaviour when selectors are empty and add coverage for re-enabling filters with selectors
- add API regression tests ensuring enabling without selectors fails with the expected validation message

## Testing
- python manage.py test displays -v 2

------
https://chatgpt.com/codex/tasks/task_e_68e4cdcebe10832aaf2e095b6f1deee5