### PR TITLE
Add schedule-aligned validation for class cancellations

### DIFF
--- a/schedules/tests.py
+++ b/schedules/tests.py
@@ -1,4 +1,4 @@
-from datetime import date, time
+from datetime import date, time, timedelta
 from django.test import TestCase
 from rest_framework.test import APIClient
 
@@ -10,6 +10,9 @@ from locations.models import Building, Classroom
 from semesters.models import Semester
 from schedules.models import ClassSession
 from schedules.services import class_session_service
+from schedules.serializers.class_adjustment_serializers import (
+    CreateClassCancellationSerializer,
+)
 from unischedule.core.exceptions import CustomValidationError
 from unischedule.core.error_codes import ErrorCodes
 
@@ -126,3 +129,74 @@ class ClassSessionModelServiceViewTests(TestCase):
 
         delete_response = other_client.delete(f"/api/schedules/{session.id}/delete/")
         self._assert_institution_required_response(delete_response)
+
+
+class ClassCancellationValidationTests(TestCase):
+    def setUp(self) -> None:
+        self.institution = Institution.objects.create(name="Uni", slug="uni-cancel")
+        self.professor = Professor.objects.create(
+            institution=self.institution,
+            first_name="Sara",
+            last_name="Karimi",
+            national_code="9876543210",
+        )
+        self.course = Course.objects.create(
+            institution=self.institution,
+            code="C2",
+            title="Course 2",
+            professor=self.professor,
+            offer_code="O2",
+            unit_count=2,
+        )
+        self.building = Building.objects.create(title="Main", institution=self.institution)
+        self.classroom = Classroom.objects.create(title="201", building=self.building)
+        self.semester = Semester.objects.create(
+            institution=self.institution,
+            title="Winter",
+            start_date=date(2024, 1, 6),
+            end_date=date(2024, 3, 30),
+        )
+
+    def _create_session(self, **overrides) -> ClassSession:
+        payload = {
+            "institution": self.institution,
+            "course": self.course,
+            "professor": self.professor,
+            "classroom": self.classroom,
+            "semester": self.semester,
+            "day_of_week": "شنبه",
+            "start_time": time(10, 0),
+            "end_time": time(12, 0),
+            "week_type": ClassSession.WeekTypeChoices.EVERY,
+        }
+        payload.update(overrides)
+        return ClassSession.objects.create(**payload)
+
+    def test_rejects_date_with_mismatched_day_of_week(self) -> None:
+        session = self._create_session()
+        serializer = CreateClassCancellationSerializer(
+            data={"class_session": session.id, "date": date(2024, 1, 7)}
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("date", serializer.errors)
+        self.assertIn("روز برگزاری", serializer.errors["date"][0])
+
+    def test_rejects_date_with_mismatched_week_type(self) -> None:
+        session = self._create_session(week_type=ClassSession.WeekTypeChoices.EVEN)
+        serializer = CreateClassCancellationSerializer(
+            data={"class_session": session.id, "date": self.semester.start_date}
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("date", serializer.errors)
+        self.assertIn("نوع هفته", serializer.errors["date"][0])
+
+    def test_accepts_matching_day_and_week_type(self) -> None:
+        session = self._create_session(week_type=ClassSession.WeekTypeChoices.EVEN)
+        valid_date = self.semester.start_date + timedelta(days=7)
+        serializer = CreateClassCancellationSerializer(
+            data={"class_session": session.id, "date": valid_date}
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)


### PR DESCRIPTION
## Summary
- validate class cancellation requests against the session day-of-week and week parity
- add serializer tests that cover rejection and acceptance cases for cancellation dates

## Testing
- python manage.py test schedules.tests.ClassCancellationValidationTests

------
https://chatgpt.com/codex/tasks/task_e_68ff7d2372d8832ab72a0ebf8fb09f43