### PR TITLE
Handle class cancellation date validation with domain errors

### DIFF
--- a/unischedule/core/error_codes.py
+++ b/unischedule/core/error_codes.py
@@ -305,6 +305,13 @@ class ErrorCodes:
         "errors": [],
         "data": {},
     }
+    CLASS_CANCELLATION_DATE_MISMATCH = {
+        "code": "4612",
+        "message": "تاریخ انتخابی با برنامه کلاس همخوانی ندارد.",
+        "status_code": status.HTTP_400_BAD_REQUEST,
+        "errors": [],
+        "data": {},
+    }
     CLASS_CANCELLATION_CREATION_FAILED = {
         "code": "4607",
         "message": "ثبت لغو جلسه با خطا مواجه شد.",


### PR DESCRIPTION
## Summary
- add a domain error code for class cancellation date mismatches and surface it from the service layer
- normalize serializer validation errors so date mismatches produce the new error response
- extend class cancellation tests to cover service-level validation behaviour

## Testing
- python manage.py test schedules.tests.ClassCancellationValidationTests

------
https://chatgpt.com/codex/tasks/task_e_68ff85b981fc832aa2379dd47e6925e4