### PR TITLE
Add documentation for schedule workflows

### DIFF
--- a/schedules/repositories/class_adjustment_repository.py
+++ b/schedules/repositories/class_adjustment_repository.py
@@ -10,12 +10,16 @@ from schedules.models import ClassCancellation, MakeupClassSession
 # --- Class cancellation operations ------------------------------------------
 
 def create_class_cancellation(data: dict) -> ClassCancellation:
+    """یک رکورد لغو کلاس را با داده‌های دریافتی ایجاد می‌کند."""
+
     return ClassCancellation.objects.create(**data)
 
 
 def update_class_cancellation_fields(
     cancellation: ClassCancellation, fields: dict
 ) -> ClassCancellation:
+    """فیلدهای دلخواه لغو کلاس را به‌روزرسانی و نمونهٔ ذخیره‌شده را بازمی‌گرداند."""
+
     for key, value in fields.items():
         setattr(cancellation, key, value)
     cancellation.save()
@@ -25,6 +29,8 @@ def update_class_cancellation_fields(
 def get_class_cancellation_by_id_and_institution(
     cancellation_id: int, institution
 ) -> ClassCancellation | None:
+    """لغو کلاس مربوط به شناسه و مؤسسهٔ مشخص را جست‌وجو می‌کند."""
+
     return (
         ClassCancellation.objects.filter(
             id=cancellation_id,
@@ -37,6 +43,8 @@ def get_class_cancellation_by_id_and_institution(
 
 
 def list_class_cancellations_by_institution(institution) -> QuerySet[ClassCancellation]:
+    """تمام لغوهای فعال یک مؤسسه را با روابط مورد نیاز برای نمایش بازمی‌گرداند."""
+
     return ClassCancellation.objects.filter(
         institution=institution,
         is_deleted=False,
@@ -48,6 +56,8 @@ def list_class_cancellations_by_institution(institution) -> QuerySet[ClassCancel
 
 
 def soft_delete_class_cancellation(cancellation: ClassCancellation) -> None:
+    """لغو کلاس را به صورت نرم حذف می‌کند تا در لیست نتایج نمایش داده نشود."""
+
     cancellation.delete()
 
 
@@ -58,6 +68,8 @@ def cancellation_exists_for_session_and_date(
     institution,
     exclude_id: int | None = None,
 ) -> bool:
+    """آیا در همان تاریخ برای جلسهٔ موردنظر قبلاً لغوی ثبت شده است یا خیر."""
+
     qs = ClassCancellation.objects.filter(
         class_session_id=class_session_id,
         date=cancellation_date,
@@ -72,12 +84,16 @@ def cancellation_exists_for_session_and_date(
 # --- Makeup session operations ---------------------------------------------
 
 def create_makeup_class_session(data: dict) -> MakeupClassSession:
+    """یک جلسهٔ جبرانی جدید بر اساس داده‌های اعتبارسنجی‌شده می‌سازد."""
+
     return MakeupClassSession.objects.create(**data)
 
 
 def update_makeup_class_session_fields(
     makeup_session: MakeupClassSession, fields: dict
 ) -> MakeupClassSession:
+    """فیلدهای جلسهٔ جبرانی را تغییر داده و نمونهٔ بروزشده را بازمی‌گرداند."""
+
     for key, value in fields.items():
         setattr(makeup_session, key, value)
     makeup_session.save()
@@ -87,6 +103,8 @@ def update_makeup_class_session_fields(
 def get_makeup_class_session_by_id_and_institution(
     makeup_id: int, institution
 ) -> MakeupClassSession | None:
+    """جلسهٔ جبرانی متعلق به مؤسسه و شناسهٔ داده شده را بازیابی می‌کند."""
+
     return (
         MakeupClassSession.objects.filter(
             id=makeup_id,
@@ -106,6 +124,8 @@ def get_makeup_class_session_by_id_and_institution(
 def list_makeup_class_sessions_by_institution(
     institution,
 ) -> QuerySet[MakeupClassSession]:
+    """جلسات جبرانی فعال یک مؤسسه را به همراه روابط کلیدی برای مصرف API فراهم می‌کند."""
+
     return MakeupClassSession.objects.filter(
         institution=institution,
         is_deleted=False,
@@ -118,6 +138,8 @@ def list_makeup_class_sessions_by_institution(
 
 
 def soft_delete_makeup_class_session(makeup_session: MakeupClassSession) -> None:
+    """جلسهٔ جبرانی را بدون حذف نهایی از پایگاه داده علامت حذف می‌کند."""
+
     makeup_session.delete()
 
 
@@ -132,6 +154,8 @@ def makeup_time_conflict_exists(
     end_time: time,
     exclude_id: int | None = None,
 ) -> bool:
+    """وجود تداخل زمانی بین جلسهٔ جبرانی مورد نظر و سایر جلسات فعال را بررسی می‌کند."""
+
     overlap = Q(start_time__lt=end_time) & Q(end_time__gt=start_time)
     qs = MakeupClassSession.objects.filter(
         institution=institution,

--- a/schedules/repositories/class_session_repository.py
+++ b/schedules/repositories/class_session_repository.py
@@ -3,18 +3,26 @@ from schedules.models import ClassSession
 
 
 def create_class_session(data: dict) -> ClassSession:
+    """یک نمونهٔ جدید از :class:`ClassSession` را بر اساس داده‌های اعتبارسنجی‌شده ذخیره می‌کند."""
+
     return ClassSession.objects.create(**data)
 
 
 def get_class_session_by_id_and_institution(session_id: int, institution) -> ClassSession | None:
+    """دریافت جلسه‌ای که متعلق به مؤسسهٔ مشخص است یا بازگرداندن ``None`` در صورت عدم وجود."""
+
     return ClassSession.objects.filter(id=session_id, institution=institution, is_deleted=False).first()
 
 
 def list_class_sessions_by_institution(institution):
+    """تمام جلسات فعال یک مؤسسه را به ترتیب ایجاد بازمی‌گرداند."""
+
     return ClassSession.objects.filter(institution=institution, is_deleted=False).order_by("-created_at")
 
 
 def update_class_session_fields(session: ClassSession, fields: dict) -> ClassSession:
+    """فیلدهای دلخواه یک جلسه را به‌روزرسانی کرده و نمونهٔ ذخیره‌شده را برمی‌گرداند."""
+
     for key, value in fields.items():
         setattr(session, key, value)
     session.save()
@@ -22,11 +30,26 @@ def update_class_session_fields(session: ClassSession, fields: dict) -> ClassSes
 
 
 def soft_delete_class_session(session: ClassSession) -> None:
+    """جلسه را بدون حذف فیزیکی غیرفعال می‌کند تا در لیست‌ها نمایش داده نشود."""
+
     session.is_deleted = True
     session.save()
 
 
-def has_time_conflict(*, institution, semester, day_of_week, start_time, end_time, week_type, classroom, professor, exclude_id: int | None = None) -> bool:
+def has_time_conflict(
+    *,
+    institution,
+    semester,
+    day_of_week,
+    start_time,
+    end_time,
+    week_type,
+    classroom,
+    professor,
+    exclude_id: int | None = None,
+) -> bool:
+    """بررسی می‌کند که آیا جلسهٔ دیگری با مشخصات مشابه در همان بازهٔ زمانی وجود دارد یا خیر."""
+
     qs = ClassSession.objects.filter(
         institution=institution,
         semester=semester,

--- a/schedules/services/class_session_service.py
+++ b/schedules/services/class_session_service.py
@@ -11,6 +11,8 @@ from schedules.services.display_invalidation import invalidate_related_displays
 
 
 def _ensure_institution(institution) -> None:
+    """اطمینان حاصل می‌کند که درخواست به یک مؤسسه معتبر متصل است."""
+
     if not institution:
         raise CustomValidationError(
             message=ErrorCodes.INSTITUTION_REQUIRED["message"],
@@ -86,6 +88,8 @@ def update_class_session(session: ClassSession, data: dict) -> dict:
 
 
 def get_class_session_instance_or_404(session_id: int, institution) -> ClassSession:
+    """نمونهٔ مدل را با اعتبارسنجی مؤسسه بازیابی کرده یا خطای دامنه‌ای پرتاب می‌کند."""
+
     _ensure_institution(institution)
     session = class_session_repository.get_class_session_by_id_and_institution(session_id, institution)
     if not session:
@@ -99,17 +103,23 @@ def get_class_session_instance_or_404(session_id: int, institution) -> ClassSess
 
 
 def get_class_session_by_id_or_404(session_id: int, institution) -> dict:
+    """دادهٔ سریال‌شدهٔ جلسه را در صورت وجود و تعلق به مؤسسه بازمی‌گرداند."""
+
     session = get_class_session_instance_or_404(session_id, institution)
     return ClassSessionSerializer(session).data
 
 
 def delete_class_session(session: ClassSession) -> None:
+    """جلسهٔ داده‌شده را حذف نرم کرده و کش نمایش‌های مرتبط را نامعتبر می‌کند."""
+
     _ensure_institution(session.institution)
     class_session_repository.soft_delete_class_session(session)
     invalidate_related_displays(session)
 
 
 def list_class_sessions(institution) -> list[dict]:
+    """لیست سریال‌شدهٔ جلسات فعال مؤسسهٔ ورودی را تولید می‌کند."""
+
     _ensure_institution(institution)
     queryset = class_session_repository.list_class_sessions_by_institution(institution)
     return ClassSessionSerializer(queryset, many=True).data

--- a/schedules/services/display_invalidation.py
+++ b/schedules/services/display_invalidation.py
@@ -38,6 +38,8 @@ def invalidate_related_displays(session: ClassSession, *, force: bool = False) -
 
 
 def _session_might_affect_screen(screen: DisplayScreen, session: ClassSession) -> bool:
+    """برآورد می‌کند که تغییرات جلسه بر خروجی نمایش موردنظر اثرگذار است یا خیر."""
+
     if not screen.filter_is_active:
         return True
 
@@ -105,6 +107,8 @@ def _session_might_affect_screen(screen: DisplayScreen, session: ClassSession) -
 
 
 def _collect_selectors(screen: DisplayScreen) -> Iterable[bool]:
+    """مجموعه‌ای از وضعیت فیلترهای فعال نمایش را به صورت بولین بازمی‌گرداند."""
+
     return (
         bool(screen.filter_classroom_id),
         bool(screen.filter_building_id),

--- a/schedules/views/class_cancellation_view.py
+++ b/schedules/views/class_cancellation_view.py
@@ -16,6 +16,8 @@ from schedules.services import class_adjustment_service
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def list_class_cancellations_view(request):
+    """لیست لغوهای ثبت‌شدهٔ مؤسسه را به صورت پاسخ استاندارد بازمی‌گرداند."""
+
     institution = request.user.institution
     try:
         cancellations = class_adjustment_service.list_class_cancellations(institution)
@@ -37,6 +39,8 @@ def list_class_cancellations_view(request):
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def create_class_cancellation_view(request):
+    """لغو جدیدی برای کلاس ثبت کرده و پیام مناسب موفقیت یا خطا برمی‌گرداند."""
+
     institution = request.user.institution
     try:
         cancellation = class_adjustment_service.create_class_cancellation(
@@ -75,6 +79,8 @@ def create_class_cancellation_view(request):
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def retrieve_class_cancellation_view(request, cancellation_id: int):
+    """جزئیات لغو مشخص را در قالب خروجی مشترک API فراهم می‌کند."""
+
     institution = request.user.institution
     try:
         cancellation = class_adjustment_service.get_class_cancellation_by_id_or_404(
@@ -98,6 +104,8 @@ def retrieve_class_cancellation_view(request, cancellation_id: int):
 @api_view(["PUT"])
 @permission_classes([IsAuthenticated])
 def update_class_cancellation_view(request, cancellation_id: int):
+    """لغو ثبت‌شده را به‌روزرسانی کرده و خطاها را به ساختار قابل‌پیش‌بینی تبدیل می‌کند."""
+
     institution = request.user.institution
     try:
         cancellation_instance = (
@@ -140,6 +148,8 @@ def update_class_cancellation_view(request, cancellation_id: int):
 @api_view(["DELETE"])
 @permission_classes([IsAuthenticated])
 def delete_class_cancellation_view(request, cancellation_id: int):
+    """لغو کلاس را حذف نرم کرده و نتیجهٔ عملیات را به صورت استاندارد گزارش می‌دهد."""
+
     institution = request.user.institution
     try:
         cancellation_instance = (

--- a/schedules/views/makeup_class_view.py
+++ b/schedules/views/makeup_class_view.py
@@ -16,6 +16,8 @@ from schedules.services import class_adjustment_service
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def list_makeup_class_sessions_view(request):
+    """لیست جلسات جبرانی مؤسسهٔ کاربر را همراه با مدیریت خطا برمی‌گرداند."""
+
     institution = request.user.institution
     try:
         makeups = class_adjustment_service.list_makeup_class_sessions(institution)
@@ -37,6 +39,8 @@ def list_makeup_class_sessions_view(request):
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def create_makeup_class_session_view(request):
+    """جلسهٔ جبرانی جدید ایجاد کرده و پاسخ استاندارد موفقیت یا خطا تولید می‌کند."""
+
     institution = request.user.institution
     try:
         makeup = class_adjustment_service.create_makeup_class_session(
@@ -75,6 +79,8 @@ def create_makeup_class_session_view(request):
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def retrieve_makeup_class_session_view(request, makeup_id: int):
+    """جزئیات جلسهٔ جبرانی مشخص را در قالب BaseResponse بازمی‌گرداند."""
+
     institution = request.user.institution
     try:
         makeup = class_adjustment_service.get_makeup_class_session_by_id_or_404(
@@ -98,6 +104,8 @@ def retrieve_makeup_class_session_view(request, makeup_id: int):
 @api_view(["PUT"])
 @permission_classes([IsAuthenticated])
 def update_makeup_class_session_view(request, makeup_id: int):
+    """جلسهٔ جبرانی موجود را به‌روزرسانی کرده و استثناها را به خطاهای سراسری تبدیل می‌کند."""
+
     institution = request.user.institution
     try:
         makeup_instance = class_adjustment_service.get_makeup_class_session_instance_or_404(
@@ -138,6 +146,8 @@ def update_makeup_class_session_view(request, makeup_id: int):
 @api_view(["DELETE"])
 @permission_classes([IsAuthenticated])
 def delete_makeup_class_session_view(request, makeup_id: int):
+    """جلسهٔ جبرانی را حذف نرم کرده و وضعیت موفق یا خطا را بازتاب می‌دهد."""
+
     institution = request.user.institution
     try:
         makeup_instance = class_adjustment_service.get_makeup_class_session_instance_or_404(


### PR DESCRIPTION
## Summary
- add descriptive docstrings to schedule repositories and services for class sessions and adjustments
- document display invalidation helper utilities and REST views handling makeup sessions and cancellations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ff93bd3fa4832a929af6273bc80b98